### PR TITLE
Fixing unwanted navigation behavior

### DIFF
--- a/app/src/main/java/com/example/jeepni/MainActivity.kt
+++ b/app/src/main/java/com/example/jeepni/MainActivity.kt
@@ -5,27 +5,30 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material3.MaterialTheme
 import androidx.navigation.NavHostController
-import com.example.jeepni.core.ui.theme.DarkColors
+import androidx.navigation.NavOptions
+import androidx.navigation.navOptions
+import com.example.jeepni.core.data.repository.AuthRepository
 import com.example.jeepni.core.ui.theme.JeepNiTheme
-import com.example.jeepni.core.ui.theme.JeepNiTypography
-import com.example.jeepni.core.ui.theme.LightColors
 import com.example.jeepni.util.Navigation
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
 @OptIn(ExperimentalAnimationApi::class)
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private lateinit var navController: NavHostController
+    @Inject
+    lateinit var auth : AuthRepository // automatically injected. no need for initialization
+
     //    private val signUpViewModel by viewModels<SignUpViewModel>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             JeepNiTheme {
                 navController = rememberAnimatedNavController()
-                Navigation(navController)
+                Navigation(navController, auth)
             }
         }
     }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/AuthRepositoryImpl.kt
@@ -39,7 +39,7 @@ class AuthRepositoryImpl (
             return User(
                 email = firebaseUser.email!!,
                 phoneNumber = "",
-                name =  firebaseUser.displayName!!,
+                name =  firebaseUser.displayName?: "",
                 route = ""
             )
         }

--- a/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInEvent.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInEvent.kt
@@ -1,4 +1,4 @@
-package com.example.jeepni.feature.authentication
+package com.example.jeepni.feature.authentication.login
 
 sealed class LogInEvent {
     data class OnEmailChange(val email : String) : LogInEvent()

--- a/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInScreen.kt
@@ -31,14 +31,12 @@ import com.example.jeepni.util.UiEvent
 fun LogInScreen(
     viewModel : LogInViewModel = hiltViewModel(),
     onNavigate : (UiEvent.Navigate) -> Unit,
-    onPopBackStack : () -> Unit,
 ){
     val context = LocalContext.current
     LaunchedEffect(key1 = true) {
         viewModel.uiEvent.collect {event ->
             when(event) {
                 is UiEvent.Navigate -> onNavigate(event)
-                is UiEvent.PopBackStack -> onPopBackStack()
                 is UiEvent.ShowToast -> {
                     Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
                 }

--- a/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInScreen.kt
@@ -1,9 +1,7 @@
 package com.example.jeepni.feature.authentication
 
 import android.widget.Toast
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
@@ -14,18 +12,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.jeepni.R
 import com.example.jeepni.core.ui.*
 import com.example.jeepni.core.ui.theme.*
+import com.example.jeepni.feature.authentication.login.LogInEvent
+import com.example.jeepni.feature.authentication.login.LogInViewModel
 import com.example.jeepni.util.UiEvent
 
 

--- a/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInViewModel.kt
@@ -69,10 +69,10 @@ class LogInViewModel @Inject constructor(
                 validNumber = event.isValid
             }
             is LogInEvent.OnSignUpClicked -> {
-                sendUiEvent(UiEvent.Navigate(Screen.SignUpScreen.route))
+                sendUiEvent(UiEvent.Navigate(Screen.SignUpScreen.route, Screen.WelcomeScreen.route))
             }
             is LogInEvent.OnBackPressed -> {
-                sendUiEvent(UiEvent.PopBackStack)
+                sendUiEvent(UiEvent.Navigate(Screen.WelcomeScreen.route, "0"))
             }
             is LogInEvent.OnLogInWithGoogle -> {
                 sendUiEvent(UiEvent.ShowToast("feature doesn't exist yet"))

--- a/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInViewModel.kt
@@ -55,7 +55,7 @@ class LogInViewModel @Inject constructor(
                     )
                     withContext(Dispatchers.Main) {
                         if (isLoggedIn) {
-                            sendUiEvent(UiEvent.Navigate(Screen.MainScreen.withArgs(email)))
+                            sendUiEvent(UiEvent.Navigate(Screen.MainScreen.route, "0"))
                         } else {
                             sendUiEvent(UiEvent.ShowToast("error"))
                         }

--- a/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/login/LogInViewModel.kt
@@ -1,12 +1,12 @@
-package com.example.jeepni.feature.authentication
+package com.example.jeepni.feature.authentication.login
 
-import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.jeepni.core.data.repository.AuthRepository
+import com.example.jeepni.feature.authentication.login.LogInEvent
 import com.example.jeepni.util.Screen
 import com.example.jeepni.util.UiEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -48,14 +48,11 @@ class LogInViewModel @Inject constructor(
                 // TODO : forgot password
             }
             is LogInEvent.OnLogInClicked -> {
-                Log.i("KYLE", "outside")
                 viewModelScope.launch {
-                    Log.i("KYLE", "before")
 
                     val isLoggedIn = repository.logInWithEmail(
                         email, password
                     )
-                    Log.i("KYLE", isLoggedIn.toString())
                     withContext(Dispatchers.Main) {
                         if (isLoggedIn) {
                             sendUiEvent(UiEvent.Navigate(Screen.MainScreen.withArgs(email)))
@@ -63,7 +60,6 @@ class LogInViewModel @Inject constructor(
                             sendUiEvent(UiEvent.ShowToast("error"))
                         }
                     }
-                    Log.i("KYLE", "after")
                 }
             }
             is LogInEvent.OnValidPasswordChange -> {

--- a/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpEvent.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpEvent.kt
@@ -1,9 +1,9 @@
-package com.example.jeepni.feature.authentication
+package com.example.jeepni.feature.authentication.signup
 
 sealed class SignUpEvent {
     data class OnEmailChange(val email : String) : SignUpEvent()
     data class OnPasswordChange(val password : String) : SignUpEvent()
-    data class OnReEnterPasswordChange(val password: String) :SignUpEvent()
+    data class OnReEnterPasswordChange(val password: String) : SignUpEvent()
     data class OnAgreeTerms(val isAgree: Boolean) : SignUpEvent()
     object OnBackClicked : SignUpEvent()
     object OnCreateAccountClicked : SignUpEvent()

--- a/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpScreen.kt
@@ -36,14 +36,12 @@ import com.example.jeepni.util.UiEvent
 fun SignUpScreen(
     viewModel: SignUpViewModel = hiltViewModel(),
     onNavigate : (UiEvent.Navigate) -> Unit,
-    onPopBackStack : () -> Unit
 ) {
     val context = LocalContext.current
     LaunchedEffect(key1 = true) {
         viewModel.uiEvent.collect {event ->
             when (event) {
                 is UiEvent.Navigate -> onNavigate(event)
-                is UiEvent.PopBackStack -> onPopBackStack()
                 is UiEvent.ShowToast -> {
                     Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
                 }

--- a/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpScreen.kt
@@ -26,6 +26,8 @@ import com.example.jeepni.core.ui.SolidButton
 import com.example.jeepni.core.ui.theme.Black
 import com.example.jeepni.core.ui.theme.JeepNiTheme
 import com.example.jeepni.core.ui.theme.White
+import com.example.jeepni.feature.authentication.signup.SignUpEvent
+import com.example.jeepni.feature.authentication.signup.SignUpViewModel
 import com.example.jeepni.util.UiEvent
 
 

--- a/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpViewModel.kt
@@ -1,9 +1,8 @@
-package com.example.jeepni.feature.authentication
+package com.example.jeepni.feature.authentication.signup
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.jeepni.core.data.repository.AuthRepository

--- a/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpViewModel.kt
@@ -63,7 +63,7 @@ class SignUpViewModel @Inject constructor(
                     val isSuccessful = repository.addUser(email.trim(), password.trim(), confirmPassword.trim())
                     withContext(Dispatchers.Main.immediate) {
                         if (isSuccessful) {
-                            sendUiEvent(UiEvent.Navigate(Screen.MainScreen.withArgs(email.trim())))
+                            sendUiEvent(UiEvent.Navigate(Screen.MainScreen.route, "0"))
                         } else {
                             sendUiEvent(UiEvent.ShowToast("failed to make account"))
                         }

--- a/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/signup/SignUpViewModel.kt
@@ -41,7 +41,7 @@ class SignUpViewModel @Inject constructor(
                 isAgreeToTerms = event.isAgree
             }
             is SignUpEvent.OnBackClicked -> {
-                sendUiEvent(UiEvent.PopBackStack)
+                sendUiEvent(UiEvent.Navigate(Screen.WelcomeScreen.route, "0"))
             }
             is SignUpEvent.OnEmailChange -> {
                 email = event.email
@@ -50,7 +50,7 @@ class SignUpViewModel @Inject constructor(
 //                sendUiEvent(UiEvent.Navigate(Screen.ForgotPasswordScreen.route))
             }
             is SignUpEvent.OnLogInClicked -> {
-                sendUiEvent(UiEvent.Navigate(Screen.LogInScreen.route))
+                sendUiEvent(UiEvent.Navigate(Screen.LogInScreen.route, Screen.WelcomeScreen.route))
             }
             is SignUpEvent.OnPasswordChange -> {
                 password = event.password

--- a/app/src/main/java/com/example/jeepni/feature/authentication/welcome/Welcome2Event.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/welcome/Welcome2Event.kt
@@ -1,4 +1,4 @@
-package com.example.jeepni.feature.authentication
+package com.example.jeepni.feature.authentication.welcome
 
 sealed class Welcome2Event {
     object OnSignUpClicked : Welcome2Event()

--- a/app/src/main/java/com/example/jeepni/feature/authentication/welcome/Welcome2Screen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/welcome/Welcome2Screen.kt
@@ -17,6 +17,8 @@ import com.example.jeepni.core.ui.SolidButton
 import com.example.jeepni.core.ui.theme.Black
 import com.example.jeepni.core.ui.theme.JeepNiTheme
 import com.example.jeepni.core.ui.theme.White
+import com.example.jeepni.feature.authentication.welcome.Welcome2Event
+import com.example.jeepni.feature.authentication.welcome.Welcome2ViewModel
 import com.example.jeepni.util.UiEvent
 
 @Composable

--- a/app/src/main/java/com/example/jeepni/feature/authentication/welcome/Welcome2ViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/welcome/Welcome2ViewModel.kt
@@ -1,7 +1,8 @@
-package com.example.jeepni.feature.authentication
+package com.example.jeepni.feature.authentication.welcome
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.jeepni.feature.authentication.welcome.Welcome2Event
 import com.example.jeepni.util.Screen
 import com.example.jeepni.util.UiEvent
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -33,7 +33,6 @@ import java.util.*
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
-    email : String,
     onNavigate : (UiEvent.Navigate) -> Unit,
     viewModel : MainViewModel = hiltViewModel(),
 ) {
@@ -81,7 +80,7 @@ fun MainScreen(
         Surface {
                 Menu(
                     drawerState = drawerState,
-                    email = email,
+                    email = viewModel.user!!.email,
                     onLogOutClick = {viewModel.onEvent(MainEvent.OnLogOutClick)}
                 ) {
                     Scaffold (

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -126,7 +126,8 @@ class MainViewModel
                             message = "Failed to log out..."
                         ))
                     } else {
-                        sendUiEvent(UiEvent.Navigate(Screen.WelcomeScreen.route))
+                        sendUiEvent(UiEvent.Navigate(
+                            Screen.WelcomeScreen.route, "0"))
                     }
                 }
             }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -22,20 +22,14 @@ class MainViewModel
 @Inject constructor(
     private val repository: DailyAnalyticsRepository,
     private val authRepo : AuthRepository,
-    savedStateHandle: SavedStateHandle //contains navigation arguments
+    //savedStateHandle: SavedStateHandle //contains navigation arguments
 )
 : ViewModel() {
 
-    var user by mutableStateOf("")
-    init {
-        user = savedStateHandle.get<String>("email") ?: ""
-//        if (userLogIn.isNotEmpty()) {
-//            viewModelScope.launch {
-//                repository.get
-//            }
-//
-//        }
-    }
+    var user by mutableStateOf(authRepo.getUser())
+//    init {
+//        user = savedStateHandle.get<String>("email") ?: ""
+//    }
 
     // create a sharedFlow for one-time events: events that you don't want to rerun on configuration changes
 

--- a/app/src/main/java/com/example/jeepni/util/Navigation.kt
+++ b/app/src/main/java/com/example/jeepni/util/Navigation.kt
@@ -75,11 +75,7 @@ fun Navigation (
         ) {
             SignUpScreen(
                 onNavigate = {
-                    navController.navigate(it.route) {
-                        popUpTo(Screen.WelcomeScreen.route) {
-                            inclusive = false
-                        }
-                    }
+                    navController.navigate(it.route, popUp(it))
                 },
                 onPopBackStack = {
                     navController.navigate(Screen.WelcomeScreen.route) {

--- a/app/src/main/java/com/example/jeepni/util/Navigation.kt
+++ b/app/src/main/java/com/example/jeepni/util/Navigation.kt
@@ -98,4 +98,26 @@ fun Navigation (
     }
 }
 
+/*
+ * helper function for Navigation():
+ *  clears the screen back stack if popUp
+ *
+ */
+    fun popUp(screen : UiEvent.Navigate) : NavOptions? {
+        if (screen.popUp == null) { // do not pop the backstack when navigating to new screen
+            return null
+        }
+        return if (screen.popUp!! == "0") { // clear the entire backstack when navigating to new screen
+            navOptions {
+                popUpTo(0) {
+                    inclusive = true
+                }
+            }
+        } else {
+            navOptions { // pop back stack until a specific screen when navigating to a new screen, not inclusive
+                popUpTo(screen.popUp!!)
+            }
+        }
+    }
+
 // https://github.com/FirebaseExtended/make-it-so-android/blob/firebase-compose-codelab-start/app/src/main/java/com/example/makeitso/MakeItSoApp.kt

--- a/app/src/main/java/com/example/jeepni/util/Navigation.kt
+++ b/app/src/main/java/com/example/jeepni/util/Navigation.kt
@@ -91,3 +91,5 @@ fun Navigation (
         }
     }
 }
+
+// https://github.com/FirebaseExtended/make-it-so-android/blob/firebase-compose-codelab-start/app/src/main/java/com/example/makeitso/MakeItSoApp.kt

--- a/app/src/main/java/com/example/jeepni/util/Navigation.kt
+++ b/app/src/main/java/com/example/jeepni/util/Navigation.kt
@@ -61,13 +61,6 @@ fun Navigation (
                 onNavigate = {
                     navController.navigate(it.route, navOptions = popUp(it))
                 },
-                onPopBackStack = {
-                    navController.navigate(Screen.WelcomeScreen.route) {
-                        popUpTo(navController.graph.id) {
-                            inclusive = true
-                        }
-                    }
-                }
             )
         }
         composable (
@@ -77,13 +70,6 @@ fun Navigation (
                 onNavigate = {
                     navController.navigate(it.route, popUp(it))
                 },
-                onPopBackStack = {
-                    navController.navigate(Screen.WelcomeScreen.route) {
-                        popUpTo(navController.graph.id) {
-                            inclusive = true
-                        }
-                    }
-                }
             )
         }
     }

--- a/app/src/main/java/com/example/jeepni/util/Navigation.kt
+++ b/app/src/main/java/com/example/jeepni/util/Navigation.kt
@@ -33,10 +33,9 @@ fun Navigation (
     ) {
         // tell the navHost how the screens look like
         composable (
-            route = Screen.MainScreen.route //+ "/{email}",// for multiple arguments "/{arg1}/{arg2}?name={optionalName}"
+            route = Screen.MainScreen.route // for multiple arguments "/{arg1}/{arg2}?name={optionalName}"
         ) {
             MainScreen(
-//                email = entry.arguments?.getString("email")!!,
                 onNavigate = {
                     navController.navigate(it.route)
                 },

--- a/app/src/main/java/com/example/jeepni/util/Navigation.kt
+++ b/app/src/main/java/com/example/jeepni/util/Navigation.kt
@@ -37,7 +37,7 @@ fun Navigation (
         ) {
             MainScreen(
                 onNavigate = {
-                    navController.navigate(it.route)
+                    navController.navigate(it.route, popUp(it))
                 },
             )
         }

--- a/app/src/main/java/com/example/jeepni/util/Navigation.kt
+++ b/app/src/main/java/com/example/jeepni/util/Navigation.kt
@@ -59,11 +59,7 @@ fun Navigation (
         ) {
             LogInScreen(
                 onNavigate = {
-                    navController.navigate(it.route) {
-                        popUpTo(Screen.WelcomeScreen.route) { // exits the app directly
-                            inclusive = false
-                        }
-                    }
+                    navController.navigate(it.route, navOptions = popUp(it))
                 },
                 onPopBackStack = {
                     navController.navigate(Screen.WelcomeScreen.route) {

--- a/app/src/main/java/com/example/jeepni/util/Navigation.kt
+++ b/app/src/main/java/com/example/jeepni/util/Navigation.kt
@@ -5,6 +5,10 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.NavOptionsBuilder
+import androidx.navigation.navOptions
+import com.example.jeepni.core.data.repository.AuthRepository
 import com.google.accompanist.navigation.animation.composable
 import com.example.jeepni.feature.authentication.LogInScreen
 import com.example.jeepni.feature.authentication.Welcome2Screen
@@ -15,22 +19,24 @@ import com.google.accompanist.navigation.animation.AnimatedNavHost
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun Navigation (
-    navController : NavHostController,
+    navController: NavHostController,
+    auth: AuthRepository,
 ) {
+
+    val initialState = if (auth.isUserLoggedIn()) Screen.MainScreen.route else Screen.WelcomeScreen.route
 
     AnimatedNavHost(
         navController = navController,
-        startDestination = Screen.WelcomeScreen.route,
+        startDestination = initialState,
         enterTransition = { EnterTransition.None},
         exitTransition = {ExitTransition.None},
     ) {
         // tell the navHost how the screens look like
         composable (
-            route = Screen.MainScreen.route + "/{email}",// for multiple arguments "/{arg1}/{arg2}?name={optionalName}"
-        ) {entry->
-            // what composable represents our main screen
+            route = Screen.MainScreen.route //+ "/{email}",// for multiple arguments "/{arg1}/{arg2}?name={optionalName}"
+        ) {
             MainScreen(
-                email = entry.arguments?.getString("email")!!,
+//                email = entry.arguments?.getString("email")!!,
                 onNavigate = {
                     navController.navigate(it.route)
                 },

--- a/app/src/main/java/com/example/jeepni/util/UiEvent.kt
+++ b/app/src/main/java/com/example/jeepni/util/UiEvent.kt
@@ -7,7 +7,7 @@ sealed class UiEvent {
         val action : String? = null
     ) : UiEvent()
 
-    data class Navigate(val route : String) : UiEvent()
+    data class Navigate(val route : String, var popUp : String? = null) : UiEvent()
 
     data class ShowToast(
         val message : String


### PR DESCRIPTION
## Fixing Navigation errors

Previously, navigation functionality from each screen was very limited. Every navigation had to follow the Screen's `onNavigate()` parameter which is set in the navigation component.

However, specific navigations may require different management of the screen backstack, which the `onNavigate()` could not account for. For example, from the main screen after logging in, pressing back shouldn't bring you back to the login screen.

To resolve this, the responsibility for setting the navigation options, more specifically the `popUpTo()` option, is now handled by the specific navigation calls in the viewModels.
    - added popUp parameter to the UiEvent.Navigate class, which allows a viewModel to specify a 'popUpTo' screen (a navigation option) when navigating to a different screen. By default it is set to null, which means that no special operations are done on the backstack.
    - [`popUp()`](https://github.com/kyle-gonzales/jeepni/commit/1ae57aa2c2d1d3534f14c271e0d4065a1a4d5f74), a helper function, assists in this process by setting how the back stack is handled during each navigation. Avoids redundant code in the NavGraph

This new system is applied in the following commits:

- ### Authentication status is kept after closing app
  - [initial screen on launch now depends on login status](https://github.com/kyle-gonzales/jeepni/commit/ff501d20e770ba31ef427fbfddaf753352165a0b)
- ### Improved Navigation to and from Authentication 
  - [cleared backstack when navigating to MainScreen from login screen](https://github.com/kyle-gonzales/jeepni/commit/ac21a69dbf6b1241c84934e339b7c054e0643ad6)
  - [cleared backstack when navigating to WelcomeScreen (logging out)](https://github.com/kyle-gonzales/jeepni/commit/ac21a69dbf6b1241c84934e339b7c054e0643ad6)
  - [cleared backstack when navigating to MainScreen from signup screen](https://github.com/kyle-gonzales/jeepni/commit/ac21a69dbf6b1241c84934e339b7c054e0643ad6)
- ### Removed repeated screens on backstack during circular navigation 
  - [added popUp options between signup and login navigation](https://github.com/kyle-gonzales/jeepni/commit/44111ae7349491b3ef36114170040ed2a7f369e6)

---

## Other changes

- added folders for different authentication screens ([commit](https://github.com/kyle-gonzales/jeepni/commit/b19f78c7f227fde1628354c69ff927229a86697b))
- removed unused parameters ([commit](https://github.com/kyle-gonzales/jeepni/commit/f0a70b3538fba3bc99e9c6ed617f1f2034f32e62))
- main screen gets user info from auth repo instead of as a navigation argument ([commit](https://github.com/kyle-gonzales/jeepni/commit/62037e236eaadd41cb3d9f9e4377a3f4364bbd0d))
