### PR TITLE
Read user's daily analytics from Firebase

### DIFF
--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepository.kt
@@ -11,6 +11,6 @@ interface DailyAnalyticsRepository {
 
     suspend fun deleteDailyStat()
 
-    fun getDailyStats() : Flow<List<DailyAnalytics>>?
+    suspend fun getDailyStats() : Flow<List<DailyAnalytics>>?
 
 }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepository.kt
@@ -1,7 +1,6 @@
 package com.example.jeepni.core.data.repository
 
 import com.example.jeepni.core.data.model.DailyAnalytics
-import kotlinx.coroutines.flow.Flow
 
 interface DailyAnalyticsRepository {
 
@@ -11,6 +10,6 @@ interface DailyAnalyticsRepository {
 
     suspend fun deleteDailyStat()
 
-    suspend fun getDailyStats() : Flow<List<DailyAnalytics>>?
+    suspend fun getDailyStats() : List<DailyAnalytics>
 
 }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
@@ -10,9 +10,14 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.CollectionReference
 import kotlinx.coroutines.flow.Flow
 
-class DailyAnalyticsRepositoryImpl (private val auth: FirebaseAuth, private val usersRef: CollectionReference, appContext: Application) :
+class DailyAnalyticsRepositoryImpl(
+    private val auth: FirebaseAuth,
+    private val usersRef: CollectionReference,
+    appContext: Application
+) :
     DailyAnalyticsRepository {
-    private var context : Context
+    private var context: Context
+
     init {
         context = appContext.applicationContext
     }
@@ -22,7 +27,9 @@ class DailyAnalyticsRepositoryImpl (private val auth: FirebaseAuth, private val 
             .collection("analytics")
             .document(getCurrentDateString())
             .set(dailyStat)
-            .addOnSuccessListener {Toast.makeText(context, "saved", Toast.LENGTH_SHORT).show()} // not sure if this works
+            .addOnSuccessListener {
+                Toast.makeText(context, "saved", Toast.LENGTH_SHORT).show()
+            } // not sure if this works
             .addOnFailureListener {}
     }
 
@@ -35,7 +42,7 @@ class DailyAnalyticsRepositoryImpl (private val auth: FirebaseAuth, private val 
             .collection("analytics")
             .document(getCurrentDateString())
             .delete()
-            .addOnSuccessListener {Toast.makeText(context, "deleted", Toast.LENGTH_SHORT).show()}
+            .addOnSuccessListener { Toast.makeText(context, "deleted", Toast.LENGTH_SHORT).show() }
             .addOnFailureListener {}
 
     }
@@ -58,5 +65,4 @@ class DailyAnalyticsRepositoryImpl (private val auth: FirebaseAuth, private val 
         // TODO: Remove nullable operator from return type and on interface
         return null
     }
-
 }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.example.jeepni.core.data.repository
 
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import com.example.jeepni.core.data.model.DailyAnalytics
 import com.example.jeepni.getCurrentDateString
@@ -40,7 +41,21 @@ class DailyAnalyticsRepositoryImpl (private val auth: FirebaseAuth, private val 
     }
 
     override fun getDailyStats(): Flow<List<DailyAnalytics>>? {
-        // TODO: implement later. remove nullable operator from return type and on interface
+        // NOTE: maybe use a persistent listener instead of a one-time get? https://firebase.google.com/docs/database/android/read-and-write#read_data_with_persistent_listeners
+        usersRef.document(auth.currentUser!!.uid)
+            .collection("analytics")
+            .get()
+            .addOnSuccessListener { result ->
+                // TODO: Turn this into a Flow<List<DailyAnalytics>> somehow
+                for (document in result) {
+                    Log.d("Firebase", "${document.id} => ${document.data}")
+                }
+            }
+            .addOnFailureListener {
+                Log.i("Firebase", "Error retrieving analytics")
+            }
+
+        // TODO: Remove nullable operator from return type and on interface
         return null
     }
 

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
@@ -47,7 +47,7 @@ class DailyAnalyticsRepositoryImpl(
 
     }
 
-    override fun getDailyStats(): Flow<List<DailyAnalytics>>? {
+    override suspend fun getDailyStats(): Flow<List<DailyAnalytics>>? {
         // NOTE: maybe use a persistent listener instead of a one-time get? https://firebase.google.com/docs/database/android/read-and-write#read_data_with_persistent_listeners
         usersRef.document(auth.currentUser!!.uid)
             .collection("analytics")


### PR DESCRIPTION
# Summary
This PR allows a user to read their currently saved analytics. It reads values from the Firestore database and shows them over on the frontend

# Changes
- Implement the `getDailyStats()` function in `DailyAnalyticsRepository` ([changes](https://github.com/kyle-gonzales/jeepni/pull/16/files#diff-65de941391850d50fc18cc948f8b98da8f4f3f9bfadc246e8d7101d1b454177eR49))
- Change the return value of `getDailyStats()` from `Flow<List<DailyAnalytics>>?` to `List<DailyAnalytics>`
- Allow `getDailyStats()` to run asynchronously 

# To-Do 
- [X] Fetch daily stats from Firestore backend
- [ ] Add a screen to display retrieved stats to the user