### PR TITLE
Get jeepney routes from backend

### DIFF
--- a/app/src/main/java/com/example/jeepni/core/data/model/Jeeps.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/Jeeps.kt
@@ -1,0 +1,9 @@
+package com.example.jeepni.core.data.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Jeeps (
+    val route : String = "",
+) : Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/repository/JeepsRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/JeepsRepository.kt
@@ -1,0 +1,8 @@
+package com.example.jeepni.core.data.repository
+
+import com.example.jeepni.core.data.model.Jeeps
+
+interface JeepsRepository {
+
+    suspend fun getJeepneyRoutes() : List<Jeeps>
+}

--- a/app/src/main/java/com/example/jeepni/core/data/repository/JeepsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/JeepsRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.example.jeepni.core.data.repository
+
+import android.app.Application
+import android.content.Context
+import com.example.jeepni.core.data.model.Jeeps
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+class JeepsRepositoryImpl(
+    appContext: Application,
+    private val auth: FirebaseAuth,
+    private val db: FirebaseFirestore
+) :
+    JeepsRepository {
+    private var context: Context
+
+    init {
+        context = appContext.applicationContext
+    }
+
+    override suspend fun getJeepneyRoutes(): List<Jeeps> {
+        val result = mutableListOf<Jeeps>()
+        val routes = db.collection("routes")
+            .get()
+            .await()
+
+        // I'm having a hard time figuring out how to convert Firebase's response into a list
+        for (route in routes.documents) result.add(Jeeps(route.id))
+
+        return result
+    }
+
+}

--- a/app/src/main/java/com/example/jeepni/di/AppModule.kt
+++ b/app/src/main/java/com/example/jeepni/di/AppModule.kt
@@ -26,6 +26,10 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideFirebaseFirestore() = Firebase.firestore
+
+    @Provides
+    @Singleton
     fun provideDailyAnalyticsRepository(
         auth : FirebaseAuth,
         usersRef : CollectionReference,

--- a/app/src/main/java/com/example/jeepni/di/AppModule.kt
+++ b/app/src/main/java/com/example/jeepni/di/AppModule.kt
@@ -1,13 +1,11 @@
 package com.example.jeepni.di
 
 import android.app.Application
-import com.example.jeepni.core.data.repository.DailyAnalyticsRepository
-import com.example.jeepni.core.data.repository.DailyAnalyticsRepositoryImpl
-import com.example.jeepni.core.data.repository.AuthRepository
-import com.example.jeepni.core.data.repository.AuthRepositoryImpl
+import com.example.jeepni.core.data.repository.*
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import dagger.Module
@@ -27,6 +25,14 @@ object AppModule {
     @Provides
     @Singleton
     fun provideFirebaseFirestore() = Firebase.firestore
+
+    @Provides
+    @Singleton
+    fun provideJeepsRepository(
+        app: Application,
+        auth : FirebaseAuth,
+        db : FirebaseFirestore
+    ) : JeepsRepository = JeepsRepositoryImpl(app, auth, db)
 
     @Provides
     @Singleton


### PR DESCRIPTION
# Summary
This PR aims to provide a list of Jeepney routes from the app's Firestore backend

# Changes
- Add a `Jeeps` model for jeepney routes ([changes](https://github.com/kyle-gonzales/jeepni/pull/17/files#diff-08f85cb18fd2ea2feb2e4c1617ce6f4125c948eac48ef21e4704a1eb8c0c4af2))
- Add a `JeepsRepository` for backend operations pertaining to jeeps ([changes](https://github.com/kyle-gonzales/jeepni/pull/17/files#diff-66f09142ee70c5d9c5a5460d422074aeac79ac889ae59b56dc991dafb0897532))
- add and implement a `getJeepneyRoutes()` function, which returns `List<Jeeps>` ([changes](https://github.com/kyle-gonzales/jeepni/pull/17/files#diff-ef8d39b9e3644e23592d2d5969248ee930aad1e88854bd963030469a3539d149))
- Provide a `JeepsRepository` implementation instance in appModule ([changes](https://github.com/kyle-gonzales/jeepni/pull/17/files#diff-303321dcf6421171359f5c70b83b2c89a0a2f9d02fe11c3d4b7e751bf200280eR29-R36))
- Provide a `FirebaseFirestore` instance in appModule ([changes](https://github.com/kyle-gonzales/jeepni/pull/17/files#diff-303321dcf6421171359f5c70b83b2c89a0a2f9d02fe11c3d4b7e751bf200280eR25-R27))

# To-Do
- [X] Retrieve a list of Jeepney routes from Firestore
- [ ] Allow user to select their jeepney route when signing up