### PR TITLE
Get user details

### DIFF
--- a/app/src/main/java/com/example/jeepni/core/data/model/Jeeps.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/Jeeps.kt
@@ -1,0 +1,9 @@
+package com.example.jeepni.core.data.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Jeeps (
+    val route : String = "",
+) : Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/model/UserCredentials.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/UserCredentials.kt
@@ -1,0 +1,11 @@
+package com.example.jeepni.core.data.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class UserCredentials(
+    val email : String,
+    val password : String,
+    val phoneNumber : String,
+): Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/model/UserDetails.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/UserDetails.kt
@@ -4,9 +4,7 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class User(
+data class UserDetails(
     val name : String,
-    val phoneNumber : String,
-    val email : String,
     val route : String,
 ): Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/AuthRepository.kt
@@ -1,6 +1,6 @@
 package com.example.jeepni.core.data.repository
 
-import com.example.jeepni.core.data.model.User
+import com.google.firebase.auth.FirebaseUser
 
 interface AuthRepository {
 
@@ -10,7 +10,7 @@ interface AuthRepository {
 
     suspend fun logInWithPhoneNumber(email : String, password : String) : Boolean
 
-    fun getUser() : User?
+    fun getUser() : FirebaseUser?
 
     fun getUserEmail() : String
 

--- a/app/src/main/java/com/example/jeepni/core/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/AuthRepository.kt
@@ -1,14 +1,15 @@
 package com.example.jeepni.core.data.repository
 
+import com.example.jeepni.core.data.model.UserCredentials
 import com.google.firebase.auth.FirebaseUser
 
 interface AuthRepository {
 
     suspend fun addUser(email: String, password: String, confirmation: String) : Boolean
 
-    suspend fun logInWithEmail(email: String, password : String) : Boolean // maybe return a response instead
+    suspend fun logInWithEmail(creds : UserCredentials) : Boolean // maybe return a response instead
 
-    suspend fun logInWithPhoneNumber(email : String, password : String) : Boolean
+    suspend fun logInWithPhoneNumber(creds : UserCredentials) : Boolean
 
     fun getUser() : FirebaseUser?
 

--- a/app/src/main/java/com/example/jeepni/core/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/AuthRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.example.jeepni.core.data.repository
 
 import android.app.Application
-import com.example.jeepni.core.data.model.User
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.tasks.await
 
 class AuthRepositoryImpl (
@@ -33,15 +33,10 @@ class AuthRepositoryImpl (
     override suspend fun logInWithPhoneNumber(email: String, password: String) : Boolean {
         return false
     }
-    override fun getUser(): User? {
+    override fun getUser(): FirebaseUser? {
         val firebaseUser = auth.currentUser
         if (firebaseUser != null) {
-            return User(
-                email = firebaseUser.email!!,
-                phoneNumber = "",
-                name =  firebaseUser.displayName!!,
-                route = ""
-            )
+            return firebaseUser
         }
         return null
     }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/AuthRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.example.jeepni.core.data.repository
 
 import android.app.Application
+import com.example.jeepni.core.data.model.UserCredentials
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.tasks.await
@@ -21,16 +22,16 @@ class AuthRepositoryImpl (
             false
         }
     }
-    override suspend fun logInWithEmail(email : String, password: String) : Boolean {
+    override suspend fun logInWithEmail(creds : UserCredentials) : Boolean {
         return try {
-            auth.signInWithEmailAndPassword(email, password).await()
+            auth.signInWithEmailAndPassword(creds.email, creds.password).await()
             true
         } catch (e : Exception) {
             e.printStackTrace()
             false
         }
     }
-    override suspend fun logInWithPhoneNumber(email: String, password: String) : Boolean {
+    override suspend fun logInWithPhoneNumber(creds : UserCredentials) : Boolean {
         return false
     }
     override fun getUser(): FirebaseUser? {

--- a/app/src/main/java/com/example/jeepni/core/data/repository/JeepsRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/JeepsRepository.kt
@@ -1,0 +1,8 @@
+package com.example.jeepni.core.data.repository
+
+import com.example.jeepni.core.data.model.Jeeps
+
+interface JeepsRepository {
+
+    suspend fun getJeepneyRoutes() : List<Jeeps>
+}

--- a/app/src/main/java/com/example/jeepni/core/data/repository/JeepsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/JeepsRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.example.jeepni.core.data.repository
+
+import android.app.Application
+import android.content.Context
+import com.example.jeepni.core.data.model.Jeeps
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+class JeepsRepositoryImpl(
+    appContext: Application,
+    private val auth: FirebaseAuth,
+    private val db: FirebaseFirestore
+) :
+    JeepsRepository {
+    private var context: Context
+
+    init {
+        context = appContext.applicationContext
+    }
+
+    override suspend fun getJeepneyRoutes(): List<Jeeps> {
+        val result = mutableListOf<Jeeps>()
+        val routes = db.collection("routes")
+            .get()
+            .await()
+
+        // I'm having a hard time figuring out how to convert Firebase's response into a list
+        for (route in routes.documents) result.add(Jeeps(route.id))
+
+        return result
+    }
+
+}

--- a/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepository.kt
@@ -6,6 +6,6 @@ interface UserDetailRepository {
 
     suspend fun getUserDetails() : User?
 
-    suspend fun  updateUserDetails(email: String, phoneNumber: String, name: String, route: String)
+    suspend fun  updateUserDetails( userDetails : User )
 
 }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepository.kt
@@ -1,11 +1,11 @@
 package com.example.jeepni.core.data.repository
 
-import com.example.jeepni.core.data.model.User
+import com.example.jeepni.core.data.model.UserDetails
 
 interface UserDetailRepository {
 
-    suspend fun getUserDetails() : User?
+    suspend fun getUserDetails() : UserDetails?
 
-    suspend fun  updateUserDetails( userDetails : User )
+    suspend fun  updateUserDetails( userDetails : UserDetails)
 
 }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepository.kt
@@ -6,6 +6,6 @@ interface UserDetailRepository {
 
     suspend fun getUserDetails() : User?
 
-    suspend fun  updateUserDetails() : Boolean
+    suspend fun  updateUserDetails(email: String, phoneNumber: String, name: String, route: String)
 
 }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepository.kt
@@ -1,0 +1,11 @@
+package com.example.jeepni.core.data.repository
+
+import com.example.jeepni.core.data.model.User
+
+interface UserDetailRepository {
+
+    suspend fun getUserDetails() : User?
+
+    suspend fun  updateUserDetails() : Boolean
+
+}

--- a/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.example.jeepni.core.data.repository
+
+import android.app.Application
+import android.content.Context
+import com.example.jeepni.core.data.model.User
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+
+class UserDetailRepositoryImpl(
+    appContext: Application,
+    private val auth: FirebaseAuth,
+    private val db: FirebaseFirestore
+) : UserDetailRepository {
+
+    private var context: Context
+
+    init {
+        context = appContext.applicationContext
+    }
+
+    override suspend fun getUserDetails(): User? {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun updateUserDetails(): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.example.jeepni.core.data.repository
 import android.app.Application
 import android.content.Context
 import android.widget.Toast
-import com.example.jeepni.core.data.model.User
+import com.example.jeepni.core.data.model.UserDetails
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
@@ -20,7 +20,7 @@ class UserDetailRepositoryImpl(
         context = appContext.applicationContext
     }
 
-    override suspend fun getUserDetails(): User? {
+    override suspend fun getUserDetails(): UserDetails? {
         val firebaseUser = auth.currentUser ?: return null
 
         val userDetails = db.collection("users")
@@ -28,17 +28,13 @@ class UserDetailRepositoryImpl(
             .get()
             .await()
 
-        return User(
-            email = userDetails.getString("email").toString(),
-            phoneNumber = userDetails.getString("phoneNumber").toString(),
+        return UserDetails(
             name =  userDetails.getString("name").toString(),
             route = userDetails.getString("route").toString()
         )
     }
 
-    override suspend fun updateUserDetails(userDetails : User) {
-        // TODO: email/phone number should update auth info too
-
+    override suspend fun updateUserDetails(userDetails : UserDetails) {
         db.collection("users")
             .document(auth.currentUser!!.uid)
             .set(userDetails)

--- a/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/UserDetailRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.example.jeepni.core.data.repository
 
 import android.app.Application
 import android.content.Context
+import android.widget.Toast
 import com.example.jeepni.core.data.model.User
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
@@ -19,10 +20,30 @@ class UserDetailRepositoryImpl(
     }
 
     override suspend fun getUserDetails(): User? {
-        TODO("Not yet implemented")
+        val firebaseUser = auth.currentUser
+        if (firebaseUser != null) {
+            return User(
+                email = firebaseUser.email!!,
+                phoneNumber = "",
+                name =  firebaseUser.displayName!!,
+                route = ""
+            )
+        }
+        return null
     }
 
-    override suspend fun updateUserDetails(): Boolean {
-        TODO("Not yet implemented")
+    override suspend fun updateUserDetails(email: String, phoneNumber: String, name: String, route: String) {
+        // TODO: email/phone number should update auth info too
+
+        val details = mapOf(
+            "name" to name,
+            "route" to route,
+        )
+
+        db.collection("users")
+            .document(auth.currentUser!!.uid)
+            .set(details)
+            .addOnSuccessListener { Toast.makeText(context, "saved", Toast.LENGTH_SHORT).show()}
+            .addOnFailureListener {}
     }
 }

--- a/app/src/main/java/com/example/jeepni/di/AppModule.kt
+++ b/app/src/main/java/com/example/jeepni/di/AppModule.kt
@@ -36,6 +36,14 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideUserDetailRepository(
+        app : Application,
+        auth : FirebaseAuth,
+        db : FirebaseFirestore
+    ) : UserDetailRepository = UserDetailRepositoryImpl(app, auth, db)
+
+    @Provides
+    @Singleton
     fun provideDailyAnalyticsRepository(
         auth : FirebaseAuth,
         usersRef : CollectionReference,

--- a/app/src/main/java/com/example/jeepni/di/AppModule.kt
+++ b/app/src/main/java/com/example/jeepni/di/AppModule.kt
@@ -26,6 +26,10 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideFirebaseFirestore() = Firebase.firestore
+
+    @Provides
+    @Singleton
     fun provideDailyAnalyticsRepository(
         auth : FirebaseAuth,
         usersRef : CollectionReference,

--- a/app/src/main/java/com/example/jeepni/di/AppModule.kt
+++ b/app/src/main/java/com/example/jeepni/di/AppModule.kt
@@ -1,13 +1,11 @@
 package com.example.jeepni.di
 
 import android.app.Application
-import com.example.jeepni.core.data.repository.DailyAnalyticsRepository
-import com.example.jeepni.core.data.repository.DailyAnalyticsRepositoryImpl
-import com.example.jeepni.core.data.repository.AuthRepository
-import com.example.jeepni.core.data.repository.AuthRepositoryImpl
+import com.example.jeepni.core.data.repository.*
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import dagger.Module
@@ -27,6 +25,14 @@ object AppModule {
     @Provides
     @Singleton
     fun provideFirebaseFirestore() = Firebase.firestore
+
+    @Provides
+    @Singleton
+    fun provideJeepsRepository(
+        app: Application,
+        auth : FirebaseAuth,
+        db : FirebaseFirestore
+    ) : JeepsRepository = JeepsRepositoryImpl(app, auth, db)
 
     @Provides
     @Singleton


### PR DESCRIPTION
# Summary

This PR aims to differentiate Auth-related user info from secondary account data (name/route/etc.) by implementing the UserDetail repo and separating the User model to UserDetail and UserCredentials.

Since a user's secondary account data includes their jeepney route, this PR also includes fetching the stored Jeepney routes from Firestore and retrieving them in the app.

# Changes
- Provide a `FirebaseFirestore` instance in appModule ([changes](a165bdddcb4f25a78a605d57f19d6f3b11b46108))

### User Credentials
- [created a UserCredentials model](https://github.com/kyle-gonzales/jeepni/pull/18/commits/61a3f3da193fd855763adb7f0f514a7f42a8bad8)
- [replaced email/password/phone number parameters with UserCredentials model](https://github.com/kyle-gonzales/jeepni/pull/18/commits/f566e73342ef3555ef4675449976e997148f42af)
- [changed getUser() in AuthRepository.kt to return a FirebaseUser (auth) directly instead of a User model](https://github.com/kyle-gonzales/jeepni/commit/3129d33a5f7944f73ae6bce898d37b31e44441e1)

### User Details
- [created a repo for User detail with the functions getUserDetails() and updateUserDetails](https://github.com/kyle-gonzales/jeepni/commit/3129d33a5f7944f73ae6bce898d37b31e44441e1)
- [Added User Detail repository to deal with the User Model](https://github.com/kyle-gonzales/jeepni/commit/0dfe01be43fc9855e1a3d021d22b6b6b2ceda30f)
- [changed updateUserDetails parameters to use the User model instead](https://github.com/kyle-gonzales/jeepni/commit/1519379bcc12173c4f2d86fbc508dbebcbe75d2c)
- [updated getUserDetails to return a User model with the appropriate data](https://github.com/kyle-gonzales/jeepni/commit/691a09eb88f870a6a799939b9f568af7d2af9094)
- [added provideUserDetailRepository() singleton](https://github.com/kyle-gonzales/jeepni/commit/1b9e9c71ab877c1902a95d8d5c47253bc0ef28f2)
- [renamed User model to UserDetails and removed auth-related components](https://github.com/kyle-gonzales/jeepni/pull/18/commits/ea58f786b96345a13ec09fe0781d25b9d96dc4be)
- [got rid of auth-related components](https://github.com/kyle-gonzales/jeepni/pull/18/commits/9ba2a60426ee358bbf3a2970119d774b4aa78122)


### Jeepney Routes
- Add a `Jeeps` model for jeepney routes ([changes](6bc8fc6e49182347e8d4b63ad057d4070e70da97))
- Add a `JeepsRepository` for backend operations pertaining to jeeps ([changes](1bd5f437afc694d5d866bef407802516c4a8d1f9))
- add and implement a `getJeepneyRoutes()` function, which returns `List<Jeeps>` ([changes](6fdeebc0d5d7cb6df5d5e95e7282496dbc65471a))

# To-Do
- [X] Retrieve a list of Jeepney routes from the Firestore database
- [X] Add separate models for a user's primary login info and their additional profile information
  - Credentials are email, password, and phone number
  - Extra info are name and jeepney route
 - [ ] Allow users to add in their details after signing up
