### PR TITLE
Save date in Daily Analytics

### DIFF
--- a/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
@@ -1,10 +1,12 @@
 package com.example.jeepni.core.data.model
 
 import android.os.Parcelable
+import com.example.jeepni.feature.home.getCurrentDateString
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class DailyAnalytics (
+    val date : String = getCurrentDateString(),
     val salary : Double = 0.0,
     val fuelCost : Double = 0.0,
 ) : Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
@@ -9,9 +9,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.CollectionReference
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.tasks.await
 
 class DailyAnalyticsRepositoryImpl(
     private val auth: FirebaseAuth,
@@ -76,9 +74,9 @@ class DailyAnalyticsRepositoryImpl(
                 }
             }
 
-            awaitClose { // cleanup
-                snapshotListener.remove()
-            }
+        awaitClose { // cleanup
+            snapshotListener.remove()
+        }
 //            for (stats in analytics.documents) result.add(
 //                DailyAnalytics(
 //                    // these strings might change, perhaps we should hardcode their values somewhere in R.values.strings
@@ -87,5 +85,5 @@ class DailyAnalyticsRepositoryImpl(
 //                )
 //            )
 
-        }
+    }
 }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
@@ -28,8 +28,11 @@ class DailyAnalyticsRepositoryImpl(
     override suspend fun logDailyStat(dailyStat: DailyAnalytics) {
         usersRef.document(auth.currentUser!!.uid)
             .collection("analytics")
-            .document(getCurrentDateString())
-            .set(dailyStat)
+            .document(dailyStat.date)
+            .set(hashMapOf(
+                "salary" to dailyStat.salary,
+                "fuelCost" to dailyStat.fuelCost
+            ))
             .addOnSuccessListener {
                 Toast.makeText(context, "saved", Toast.LENGTH_SHORT).show()
             } // not sure if this works

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -73,7 +73,7 @@ class MainViewModel
                 if (isValidFuelCost && isValidSalary) {
                     viewModelScope.launch {
                         repository.updateDailyStat(
-                            DailyAnalytics(event.salary, event.fuelCost)
+                            DailyAnalytics(salary = event.salary, fuelCost = event.fuelCost)
                         )
                     }
                 } else {

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -3,7 +3,6 @@ package com.example.jeepni.feature.home
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.jeepni.core.data.model.DailyAnalytics
@@ -21,10 +20,9 @@ import javax.inject.Inject
 class MainViewModel
 @Inject constructor(
     private val repository: DailyAnalyticsRepository,
-    private val authRepo : AuthRepository,
+    private val authRepo: AuthRepository,
     //savedStateHandle: SavedStateHandle //contains navigation arguments
-)
-: ViewModel() {
+) : ViewModel() {
 
     var user by mutableStateOf(authRepo.getUser())
 //    init {
@@ -39,7 +37,7 @@ class MainViewModel
     //think about the user interactions that may happen in the main activity
     // event class -> events from the screen to the ViewModel when there is a user interaction
 
-    private var deletedStat : DailyAnalytics? = null // user can undo deleted stat
+    private var deletedStat: DailyAnalytics? = null // user can undo deleted stat
 
     var salary by mutableStateOf("100")
         private set
@@ -64,7 +62,7 @@ class MainViewModel
 
 
     fun onEvent(event: MainEvent) {
-        when(event) {
+        when (event) {
             is MainEvent.OnOpenAddDailyStatDialog -> {
                 isAddDailyStatDialogOpen = event.value
             }
@@ -96,10 +94,12 @@ class MainViewModel
                     viewModelScope.launch {
                         repository.updateDailyStat(deletedStat ?: return@launch)
                         deletedStat = null
-                        sendUiEvent(UiEvent.ShowSnackBar(
-                            message = "Daily Analytics Deleted",
-                            action = "Undo"
-                        ))
+                        sendUiEvent(
+                            UiEvent.ShowSnackBar(
+                                message = "Daily Analytics Deleted",
+                                action = "Undo"
+                            )
+                        )
                     }
                 }
             }
@@ -108,7 +108,7 @@ class MainViewModel
                 isValidSalary = isValidDecimal(salary)
             }
             is MainEvent.OnFuelCostChange -> {
-                fuelCost= event.fuelCost
+                fuelCost = event.fuelCost
                 isValidFuelCost = isValidDecimal(fuelCost)
             }
             is MainEvent.OnDistanceChange -> {
@@ -122,12 +122,17 @@ class MainViewModel
                 viewModelScope.launch {
                     authRepo.logOut()
                     if (authRepo.isUserLoggedIn()) {
-                        sendUiEvent(UiEvent.ShowSnackBar(
-                            message = "Failed to log out..."
-                        ))
+                        sendUiEvent(
+                            UiEvent.ShowSnackBar(
+                                message = "Failed to log out..."
+                            )
+                        )
                     } else {
-                        sendUiEvent(UiEvent.Navigate(
-                            Screen.WelcomeScreen.route, "0"))
+                        sendUiEvent(
+                            UiEvent.Navigate(
+                                Screen.WelcomeScreen.route, "0"
+                            )
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Currently, the analytics page is limited to using a hardcoded date when showing the list of analytics. This is because the backend doesn't provide the dates when fetching analytics. This PR solves that by including dates.

# Changes
- Basic code formatting 
- Add `val date : String` to the `DailyAnalytics` model (still defaults to current date)
- Include dates when fetching from `getDailyStats()`
- Allow `logDailyStat()` to log the stats for any day, not just today
  - Since we're including `date` in the model now, it makes sense to save according to the model's date value, instead of only ever saving today's date value. Otherwise, we might provide `date="1/1/2021"` and be surprised that it doesn't get saved under that date
  - NOTE: in the current implementation, `date` still defaults to the current date automatically. This is because we're not supplying any date values, so it defaults to "today".