### PR TITLE
Hotfix for the navigation and AboutDriverViewModel(Issue #22)

### DIFF
--- a/app/src/main/java/com/example/jeepni/core/ui/Composables.kt
+++ b/app/src/main/java/com/example/jeepni/core/ui/Composables.kt
@@ -1,8 +1,6 @@
 package com.example.jeepni.core.ui
 
 import androidx.compose.foundation.Image
-
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,43 +8,26 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowUp
-
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Brush
-
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
-
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.*
-
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.toSize
-
 import com.example.jeepni.R
-import com.example.jeepni.core.ui.theme.Black
 import com.example.jeepni.core.ui.theme.JeepNiTheme
-import com.example.jeepni.core.ui.theme.White
 import com.example.jeepni.core.ui.theme.quicksandFontFamily
 
 @Composable
@@ -298,8 +279,8 @@ fun CustomDropDown(
                 modifier = Modifier
                     .fillMaxWidth()
                     .onGloballyPositioned {
-                    onSizeChange(it.size.toSize())
-                }
+                        onSizeChange(it.size.toSize())
+                    }
             )
             DropdownMenu(
                 expanded = expanded,
@@ -371,6 +352,49 @@ fun AnalyticsCard(
             }
         }
     }
+}
+
+@Composable
+fun JeepNiAlertDialog(
+    modifier : Modifier = Modifier,
+    isOpen : Boolean,
+    onDismiss : () -> Unit,
+    onConfirm : () -> Unit,
+    confirmText : String = "Confirm",
+    dismissText : String = "Cancel",
+    titleText : String = "Alert",
+    icon : @Composable () -> Unit,
+    content : @Composable () -> Unit,
+) {
+    Surface {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            modifier = modifier,
+            confirmButton = {
+                TextButton(onClick = {
+                    onDismiss()
+                    onConfirm()
+                }
+                ) {
+                    Text(confirmText, fontFamily = quicksandFontFamily)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = onDismiss,
+                ) {
+                    Text(dismissText, fontFamily = quicksandFontFamily)
+                }
+            },
+            title = {
+                Text(titleText, fontFamily = quicksandFontFamily)
+            },
+            icon = icon,
+            text = content,
+        )
+
+    }
+
 }
 
 //@Composable

--- a/app/src/main/java/com/example/jeepni/feature/about/AboutDriverEvent.kt
+++ b/app/src/main/java/com/example/jeepni/feature/about/AboutDriverEvent.kt
@@ -8,5 +8,7 @@ sealed class AboutDriverEvent {
     data class OnRouteDropDownClick(val isOpen: Boolean) : AboutDriverEvent()
     data class OnRouteChange (val route: Int): AboutDriverEvent()
     data class OnRouteSizeChange(val s: Size): AboutDriverEvent()
-    object OnBackPressesd : AboutDriverEvent()
+    object OnBackPress : AboutDriverEvent()
+    object OnDialogDismissPress : AboutDriverEvent()
+    object OnDialogConfirmPress : AboutDriverEvent()
 }

--- a/app/src/main/java/com/example/jeepni/feature/about/AboutDriverScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/about/AboutDriverScreen.kt
@@ -2,6 +2,7 @@ package com.example.jeepni.feature.about
 
 import android.annotation.SuppressLint
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -36,6 +37,10 @@ fun AboutDriverScreen(
     onNavigate : (UiEvent.Navigate) -> Unit,
     onPopBackStack : () -> Unit
 ) {
+
+    BackHandler {
+        viewModel.onEvent(AboutDriverEvent.OnBackPress)
+    }
 
     val routes = viewModel.jeepneyRoutes.mapTo(arrayListOf()) { it.route }
     val context = LocalContext.current
@@ -79,9 +84,7 @@ fun AboutDriverScreen(
                             navigationIcon = {
                                 IconButton(
                                     onClick = {
-
-                                        viewModel.onEvent(AboutDriverEvent.OnBackPressesd)
-
+                                        viewModel.onEvent(AboutDriverEvent.OnBackPress)
                                     }
                                 ) {
                                     Icon(Icons.Filled.ArrowBack, contentDescription = null)

--- a/app/src/main/java/com/example/jeepni/feature/about/AboutDriverScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/about/AboutDriverScreen.kt
@@ -7,20 +7,20 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-
 import com.example.jeepni.R
-import com.example.jeepni.core.data.model.Jeeps
+
 import com.example.jeepni.core.ui.CustomDropDown
+import com.example.jeepni.core.ui.JeepNiAlertDialog
 import com.example.jeepni.core.ui.JeepNiTextField
 import com.example.jeepni.core.ui.SolidButton
 
@@ -131,6 +131,23 @@ fun AboutDriverScreen(
                     }
                 }
             )
+        }
+    }
+
+    if (viewModel.isDialogOpen) {
+        JeepNiAlertDialog(
+            isOpen = viewModel.isDialogOpen,
+            onDismiss = {
+                viewModel.onEvent(AboutDriverEvent.OnDialogDismissPress)
+            }, onConfirm = {
+                viewModel.onEvent(AboutDriverEvent.OnDialogConfirmPress)
+            }, icon = {
+                Icon(painterResource(R.drawable.logout_white_24), null)
+            },
+            titleText = "Logout?"
+        ) {
+            Text("It seems that you haven't completed your user profile... Going back to the previous screen will sign you out",
+                fontFamily = quicksandFontFamily)
         }
     }
 }

--- a/app/src/main/java/com/example/jeepni/feature/about/AboutDriverViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/about/AboutDriverViewModel.kt
@@ -91,8 +91,20 @@ class AboutDriverViewModel
             is AboutDriverEvent.OnRouteSizeChange -> {
                 routeDropdownSize = event.s
             }
-            is AboutDriverEvent.OnBackPressesd -> {
-                sendUiEvent(UiEvent.Navigate(Screen.WelcomeScreen.route, "0")) // TODO: fix this. user still remains logged in while in the welcome screen
+            is AboutDriverEvent.OnBackPress -> {
+                isDialogOpen = true
+            }
+            is AboutDriverEvent.OnDialogConfirmPress -> {
+                auth.logOut()
+                // TODO: create an alert dialog to inform the user that they are being logged out
+                if (! auth.isUserLoggedIn()) {
+                    sendUiEvent(UiEvent.Navigate(Screen.WelcomeScreen.route, "0"))
+                } else {
+                    sendUiEvent(UiEvent.ShowToast("failed to log out..."))
+                }
+            }
+            is AboutDriverEvent.OnDialogDismissPress -> {
+                isDialogOpen = false
             }
         }
     }

--- a/app/src/main/java/com/example/jeepni/feature/about/AboutDriverViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/about/AboutDriverViewModel.kt
@@ -90,7 +90,7 @@ class AboutDriverViewModel
                 routeDropdownSize = event.s
             }
             is AboutDriverEvent.OnBackPressesd -> {
-                sendUiEvent(UiEvent.PopBackStack)
+                sendUiEvent(UiEvent.Navigate(Screen.WelcomeScreen.route, "0")) // TODO: fix this. user still remains logged in while in the welcome screen
             }
         }
     }

--- a/app/src/main/java/com/example/jeepni/feature/about/AboutDriverViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/about/AboutDriverViewModel.kt
@@ -46,6 +46,8 @@ class AboutDriverViewModel
         private set
     var isValidFirstName by mutableStateOf(true)
         private set
+    var isDialogOpen by mutableStateOf(false)
+        private set
 
 
     private val _uiEvent = Channel<UiEvent>()

--- a/app/src/main/java/com/example/jeepni/util/Navigation.kt
+++ b/app/src/main/java/com/example/jeepni/util/Navigation.kt
@@ -1,19 +1,18 @@
 package com.example.jeepni.util
 
+import android.util.Log
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.navOptions
 import com.example.jeepni.core.data.model.UserDetails
 import com.example.jeepni.core.data.repository.AuthRepository
-import com.example.jeepni.feature.analytics.AnalyticsScreen
-import com.google.accompanist.navigation.animation.composable
 import com.example.jeepni.core.data.repository.UserDetailRepository
 import com.example.jeepni.feature.about.AboutDriverScreen
+import com.example.jeepni.feature.analytics.AnalyticsScreen
 import com.example.jeepni.feature.authentication.LogInScreen
 import com.example.jeepni.feature.authentication.SignUpScreen
 import com.example.jeepni.feature.authentication.Welcome2Screen
@@ -22,6 +21,7 @@ import com.example.jeepni.feature.home.MainScreen
 import com.example.jeepni.feature.profile.ProfileScreen
 import com.google.accompanist.navigation.animation.AnimatedNavHost
 import com.google.accompanist.navigation.animation.composable
+import kotlinx.coroutines.runBlocking
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -31,7 +31,8 @@ fun Navigation (
     userDetailRepository: UserDetailRepository,
 ) {
     var userDetails : UserDetails? = null
-    LaunchedEffect(Unit) {
+    runBlocking {
+        // kinda blocked the main thread... on purpose... but in a normal coroutine, initialState won't wait for userDetails to finish initializing. That's why, previously, initialState would always be in WelcomeScreen (userDetails is null) even if the user was signed in...
         userDetails = userDetailRepository.getUserDetails()
     }
 
@@ -63,6 +64,7 @@ fun Navigation (
         composable (
             route = Screen.WelcomeScreen.route
         ) {
+            Log.i("LOGIN STATUS", auth.getUser()?.let {it.email + " is logged in"}?: "user is not logged in")
             Welcome2Screen(
                 onNavigate = {
                     navController.navigate(it.route) {

--- a/app/src/main/res/drawable/logout_white_24.xml
+++ b/app/src/main/res/drawable/logout_white_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17,7l-1.41,1.41L18.17,11H8v2h10.17l-2.58,2.58L17,17l5,-5zM4,5h8V3H4c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h8v-2H4V5z"/>
+</vector>


### PR DESCRIPTION
In Issue: #22  , when the user is greeted with the `WelcomeScreen`, the user thinks they are logged out, except in the scenario of pressing the log out button in the profile screen which, thankfully, works perfectly fine. In every other scenario, however, the user is still logged in. This raises some possible security issues.

This pull request aims to addresse this issue, while creating a more intuitive behavior when using JeepNi

## Changes
- changed LaunchedEffect to runBlocking when getting userDetails ([changes](https://github.com/kyle-gonzales/jeepni/commit/1aa2db09e056cdb28e8bc087622d08a66ab5e53b#diff-d1d9ac5d85699ec219680118b27024443482bb1f079264853351e9c28a26e82cR34-R36))
  - This change resolves the initial issue: whenever the user closes the app, regardless of the current screen, the user is greeted witht the `WelcomeScreen`, even if they are still logged in, "under the hood".
- fixed the broken back button in the action bar: the user is now led back to the WelcomeScreen ([changes](https://github.com/kyle-gonzales/jeepni/commit/bbe94967ea875d8ecb295c4f109752ee1402f4fd#diff-90e6d012723a09b6ee5f17bff661a06b44a81727f4691180c478279d858b78c2R92-R94))
  - This change re-creates the previous issue (logged in while in the `WelcomeScreen`), **but only for this specific screen**.

- added a BackHandler effect in `AboutScreen`. ([changes](https://github.com/kyle-gonzales/jeepni/commit/ff6fcd4830642563d66ed0e47047234a95cdc540#diff-f820b9f39774ad7e8c7e6ca00a861491b139a92a8f97a4f065c5cbc690351be5R41-R44))
  - allows the system back press and the back button on the action bar to have virtually identical functionality.
-  Added an alert dialog when the user presses either back button. It informs the user that back button will log them out. ([changes](https://github.com/kyle-gonzales/jeepni/commit/5aa420b42df017bdacc28bea509143906ba84570#diff-f820b9f39774ad7e8c7e6ca00a861491b139a92a8f97a4f065c5cbc690351be5R137-R152)) 
   - When the user confirms, they are redirected to the `WelcomeScreen` and the user is logged out of their account, effectively fixing the previous issue. ([changes](https://github.com/kyle-gonzales/jeepni/commit/b3467463ab936a77edc925112c11256924f9e467#diff-90e6d012723a09b6ee5f17bff661a06b44a81727f4691180c478279d858b78c2R94-R108))
