### PR TITLE
feature: Display map that is updated with user's location

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,9 +76,9 @@ dependencies {
     testImplementation "com.google.dagger:hilt-android-testing:$dagger_hilt_version"
     kaptTest "com.google.dagger:hilt-compiler:$dagger_hilt_version"
 
-
-//    implementation "io.github.raamcosta.compose-destinations:core$compose_destination_version"
-//    ksp "io.github.raamcosta.compose-destinations:ksp:$compose_destination_version"
+    // Dependencies for Google Map
+    implementation "com.google.android.gms:play-services-maps:18.1.0"
+    implementation "com.google.maps.android:maps-copmpose:2.2.0"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth-ktx:21.0.3'
     implementation 'com.google.firebase:firebase-firestore-ktx:24.4.4'
 
-
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10' // checks for memory leaks
 
     // Add the dependencies for any other desired Firebase products
     // https://firebase.google.com/docs/android/setup#available-libraries

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,7 +79,7 @@ dependencies {
 
     // Dependencies for Google Map
     implementation "com.google.android.gms:play-services-maps:18.1.0"
-    implementation "com.google.android.gms:play-services-location:21.0.1"
+    implementation "com.google.android.gms:play-services-location:21.0.1" // for getting user location
 
     implementation "com.google.maps.android:maps-compose:2.2.0" // compose support for google maps
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'kotlin-kapt'
     id 'com.google.dagger.hilt.android'
     id 'kotlin-parcelize'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 android {
@@ -78,7 +79,12 @@ dependencies {
 
     // Dependencies for Google Map
     implementation "com.google.android.gms:play-services-maps:18.1.0"
-    implementation "com.google.maps.android:maps-copmpose:2.2.0"
+    implementation "com.google.android.gms:play-services-location:21.0.1"
+
+    implementation "com.google.maps.android:maps-compose:2.2.0" // compose support for google maps
+
+    implementation "com.google.maps.android:maps-ktx:3.2.1" // kotlin extensions for maps
+    implementation "com.google.maps.android:maps-utils-ktx:3.2.1"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,11 @@
             </intent-filter>
 
         </activity>
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${MAPS_API_KEY}"
+            />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
 
     <application
         android:name=".JeepNiApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@drawable/samplelogo"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+
     <application
         android:name=".JeepNiApp"
         android:allowBackup="true"

--- a/app/src/main/java/com/example/jeepni/MainActivity.kt
+++ b/app/src/main/java/com/example/jeepni/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavHostController
 import com.example.jeepni.core.data.repository.AuthRepository
 import com.example.jeepni.core.data.repository.UserDetailRepository
@@ -12,6 +11,7 @@ import com.example.jeepni.core.ui.theme.JeepNiTheme
 import com.example.jeepni.feature.analytics.AnalyticsViewModel
 import com.example.jeepni.util.Navigation
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
+import com.google.android.gms.location.*
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/app/src/main/java/com/example/jeepni/core/ui/Composables.kt
+++ b/app/src/main/java/com/example/jeepni/core/ui/Composables.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.*
 import com.example.jeepni.R
 import com.example.jeepni.core.ui.theme.JeepNiTheme
 import com.example.jeepni.core.ui.theme.quicksandFontFamily
+import com.example.jeepni.util.PermissionTextProvider
 
 @Composable
 fun Gradient(
@@ -391,6 +392,56 @@ fun JeepNiAlertDialog(
             },
             icon = icon,
             text = content,
+        )
+
+    }
+
+}
+
+@Composable
+fun PermissionDialog(
+    permissionTextProvider: PermissionTextProvider,
+    isPermanentlyDeclined: Boolean,
+    onDismiss : () -> Unit,
+    onConfirm : () -> Unit,
+    onGoToAppSettings : () -> Unit, // action when permissions are "permanently declined" (user declines permissions more than two times)
+) {
+
+    Surface {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            confirmButton = {
+                TextButton(onClick = {
+                    onDismiss()
+                    if (isPermanentlyDeclined) {
+                        onGoToAppSettings()
+                    } else {
+                        onConfirm()
+                    }
+                }
+                ) {
+                    Text(text = if (isPermanentlyDeclined) {
+                        "Grant Permissions"
+                    } else {
+                        "OK"
+                    }, fontFamily = quicksandFontFamily)
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = onDismiss,
+                ) {
+                    Text("Cancel", fontFamily = quicksandFontFamily)
+                }
+            },
+            title = {
+                Text("Permission Required", fontFamily = quicksandFontFamily)
+            },
+            text = {
+               Text(
+                   text = permissionTextProvider.getDescription(isPermanentlyDeclined)
+               )
+            },
         )
 
     }

--- a/app/src/main/java/com/example/jeepni/di/AppModule.kt
+++ b/app/src/main/java/com/example/jeepni/di/AppModule.kt
@@ -1,7 +1,9 @@
 package com.example.jeepni.di
 
 import android.app.Application
+import android.content.Context
 import com.example.jeepni.core.data.repository.*
+import com.google.android.gms.location.LocationServices
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.CollectionReference
@@ -11,6 +13,7 @@ import com.google.firebase.ktx.Firebase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -60,7 +63,11 @@ object AppModule {
 
     @Provides
     @Singleton
-
     fun provideFirebaseAuth () = Firebase.auth
 
+    @Provides
+    @Singleton
+    fun providesFusedLocationProviderClient (
+        @ApplicationContext context : Context
+    ) = LocationServices.getFusedLocationProviderClient(context)
 }

--- a/app/src/main/java/com/example/jeepni/feature/home/GoogleMapID.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/GoogleMapID.kt
@@ -1,0 +1,8 @@
+package com.example.jeepni.feature.home
+
+object GoogleMapID {
+
+
+    val lightMode = "d0175a39caee6cd7"
+    val darkMode = "d96988f0aed18208"
+}

--- a/app/src/main/java/com/example/jeepni/feature/home/JsonMapStyle.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/JsonMapStyle.kt
@@ -6,210 +6,704 @@ object JsonMapStyle {
     val LIGHT_MAP_STYLE =
     """
         [
-          {
-            "featureType": "water",
-            "elementType": "geometry",
-            "stylers": [
-              {
-                "color": "#069420"
-              }
-            ]
-          }
+            {
+                "featureType": "administrative",
+                "elementType": "labels.text.fill",
+                "stylers": [
+                    {
+                        "color": "#444444"
+                    }
+                ]
+            },
+            {
+                "featureType": "administrative.province",
+                "elementType": "labels",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    }
+                ]
+            },
+            {
+                "featureType": "administrative.locality",
+                "elementType": "labels",
+                "stylers": [
+                    {
+                        "visibility": "on"
+                    }
+                ]
+            },
+            {
+                "featureType": "administrative.neighborhood",
+                "elementType": "labels",
+                "stylers": [
+                    {
+                        "visibility": "on"
+                    }
+                ]
+            },
+            {
+                "featureType": "landscape",
+                "elementType": "all",
+                "stylers": [
+                    {
+                        "color": "#ffffff"
+                    }
+                ]
+            },
+            {
+                "featureType": "poi",
+                "elementType": "all",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    },
+                    {
+                        "weight": "1.00"
+                    }
+                ]
+            },
+            {
+                "featureType": "poi",
+                "elementType": "labels",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    }
+                ]
+            },
+            {
+                "featureType": "poi",
+                "elementType": "labels.text",
+                "stylers": [
+                    {
+                        "color": "#5c8459"
+                    }
+                ]
+            },
+            {
+                "featureType": "poi",
+                "elementType": "labels.icon",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    },
+                    {
+                        "color": "#5c8459"
+                    }
+                ]
+            },
+            {
+                "featureType": "poi.attraction",
+                "elementType": "labels.icon",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    }
+                ]
+            },
+            {
+                "featureType": "poi.business",
+                "elementType": "all",
+                "stylers": [
+                    {
+                        "visibility": "simplified"
+                    }
+                ]
+            },
+            {
+                "featureType": "poi.business",
+                "elementType": "geometry",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    }
+                ]
+            },
+            {
+                "featureType": "poi.business",
+                "elementType": "labels",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    }
+                ]
+            },
+            {
+                "featureType": "road",
+                "elementType": "all",
+                "stylers": [
+                    {
+                        "saturation": -100
+                    },
+                    {
+                        "lightness": 45
+                    },
+                    {
+                        "visibility": "on"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.highway",
+                "elementType": "all",
+                "stylers": [
+                    {
+                        "visibility": "simplified"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.highway",
+                "elementType": "geometry",
+                "stylers": [
+                    {
+                        "visibility": "on"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.highway",
+                "elementType": "geometry.fill",
+                "stylers": [
+                    {
+                        "weight": "10.00"
+                    },
+                    {
+                        "color": "#ffffff"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.highway",
+                "elementType": "geometry.stroke",
+                "stylers": [
+                    {
+                        "weight": "2"
+                    },
+                    {
+                        "color": "#99c1a3"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.highway.controlled_access",
+                "elementType": "geometry",
+                "stylers": [
+                    {
+                        "visibility": "on"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.highway.controlled_access",
+                "elementType": "geometry.stroke",
+                "stylers": [
+                    {
+                        "color": "#99c1a3"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.highway.controlled_access",
+                "elementType": "labels",
+                "stylers": [
+                    {
+                        "visibility": "on"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.arterial",
+                "elementType": "all",
+                "stylers": [
+                    {
+                        "visibility": "on"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.arterial",
+                "elementType": "geometry.fill",
+                "stylers": [
+                    {
+                        "weight": "10.00"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.arterial",
+                "elementType": "geometry.stroke",
+                "stylers": [
+                    {
+                        "weight": "2"
+                    },
+                    {
+                        "color": "#99c1a3"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.arterial",
+                "elementType": "labels.text.fill",
+                "stylers": [
+                    {
+                        "weight": "1"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.arterial",
+                "elementType": "labels.text.stroke",
+                "stylers": [
+                    {
+                        "weight": "1"
+                    },
+                    {
+                        "visibility": "on"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.arterial",
+                "elementType": "labels.icon",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    }
+                ]
+            },
+            {
+                "featureType": "road.local",
+                "elementType": "all",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    }
+                ]
+            },
+            {
+                "featureType": "transit",
+                "elementType": "all",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    }
+                ]
+            },
+            {
+                "featureType": "water",
+                "elementType": "all",
+                "stylers": [
+                    {
+                        "color": "#6dadc7"
+                    },
+                    {
+                        "visibility": "on"
+                    }
+                ]
+            },
+            {
+                "featureType": "water",
+                "elementType": "labels",
+                "stylers": [
+                    {
+                        "visibility": "off"
+                    }
+                ]
+            }
         ]
-        
     """.trimIndent()
     val DARK_MAP_STYLE =
         """
             [
-              {
-                "featureType": "all",
-                "elementType": "geometry",
-                "stylers": [
-                  {
-                    "color": "#242f3e"
-                  }
-                ]
-              },
-              {
-                "featureType": "all",
-                "elementType": "labels.text.stroke",
-                "stylers": [
-                  {
-                    "lightness": -80
-                  }
-                ]
-              },
-              {
-                "featureType": "administrative",
-                "elementType": "labels.text.fill",
-                "stylers": [
-                  {
-                    "color": "#746855"
-                  }
-                ]
-              },
-              {
-                "featureType": "administrative.locality",
-                "elementType": "labels.text.fill",
-                "stylers": [
-                  {
-                    "color": "#d59563"
-                  }
-                ]
-              },
-              {
-                "featureType": "poi",
-                "elementType": "labels.text.fill",
-                "stylers": [
-                  {
-                    "color": "#d59563"
-                  }
-                ]
-              },
-              {
-                "featureType": "poi.park",
-                "elementType": "geometry",
-                "stylers": [
-                  {
-                    "color": "#263c3f"
-                  }
-                ]
-              },
-              {
-                "featureType": "poi.park",
-                "elementType": "labels.text.fill",
-                "stylers": [
-                  {
-                    "color": "#6b9a76"
-                  }
-                ]
-              },
-              {
-                "featureType": "road",
-                "elementType": "geometry.fill",
-                "stylers": [
-                  {
-                    "color": "#2b3544"
-                  }
-                ]
-              },
-              {
-                "featureType": "road",
-                "elementType": "labels.text.fill",
-                "stylers": [
-                  {
-                    "color": "#9ca5b3"
-                  }
-                ]
-              },
-              {
-                "featureType": "road.arterial",
-                "elementType": "geometry.fill",
-                "stylers": [
-                  {
-                    "color": "#38414e"
-                  }
-                ]
-              },
-              {
-                "featureType": "road.arterial",
-                "elementType": "geometry.stroke",
-                "stylers": [
-                  {
-                    "color": "#212a37"
-                  }
-                ]
-              },
-              {
-                "featureType": "road.highway",
-                "elementType": "geometry.fill",
-                "stylers": [
-                  {
-                    "color": "#746855"
-                  }
-                ]
-              },
-              {
-                "featureType": "road.highway",
-                "elementType": "geometry.stroke",
-                "stylers": [
-                  {
-                    "color": "#1f2835"
-                  }
-                ]
-              },
-              {
-                "featureType": "road.highway",
-                "elementType": "labels.text.fill",
-                "stylers": [
-                  {
-                    "color": "#f3d19c"
-                  }
-                ]
-              },
-              {
-                "featureType": "road.local",
-                "elementType": "geometry.fill",
-                "stylers": [
-                  {
-                    "color": "#38414e"
-                  }
-                ]
-              },
-              {
-                "featureType": "road.local",
-                "elementType": "geometry.stroke",
-                "stylers": [
-                  {
-                    "color": "#212a37"
-                  }
-                ]
-              },
-              {
-                "featureType": "transit",
-                "elementType": "geometry",
-                "stylers": [
-                  {
-                    "color": "#2f3948"
-                  }
-                ]
-              },
-              {
-                "featureType": "transit.station",
-                "elementType": "labels.text.fill",
-                "stylers": [
-                  {
-                    "color": "#d59563"
-                  }
-                ]
-              },
-              {
-                "featureType": "water",
-                "elementType": "geometry",
-                "stylers": [
-                  {
-                    "color": "#17263c"
-                  }
-                ]
-              },
-              {
-                "featureType": "water",
-                "elementType": "labels.text.fill",
-                "stylers": [
-                  {
-                    "color": "#515c6d"
-                  }
-                ]
-              },
-              {
-                "featureType": "water",
-                "elementType": "labels.text.stroke",
-                "stylers": [
-                  {
-                    "lightness": -20
-                  }
-                ]
-              }
+                {
+                    "featureType": "administrative.province",
+                    "elementType": "labels",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "administrative.locality",
+                    "elementType": "all",
+                    "stylers": [
+                        {
+                            "visibility": "on"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "administrative.locality",
+                    "elementType": "labels",
+                    "stylers": [
+                        {
+                            "visibility": "on"
+                        },
+                        {
+                            "color": "#ff0000"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "administrative.locality",
+                    "elementType": "labels.text.fill",
+                    "stylers": [
+                        {
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "administrative.locality",
+                    "elementType": "labels.text.stroke",
+                    "stylers": [
+                        {
+                            "color": "#283129"
+                        },
+                        {
+                            "visibility": "on"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "administrative.neighborhood",
+                    "elementType": "labels",
+                    "stylers": [
+                        {
+                            "visibility": "on"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "administrative.neighborhood",
+                    "elementType": "labels.text.fill",
+                    "stylers": [
+                        {
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "administrative.neighborhood",
+                    "elementType": "labels.text.stroke",
+                    "stylers": [
+                        {
+                            "color": "#283129"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "landscape",
+                    "elementType": "all",
+                    "stylers": [
+                        {
+                            "color": "#283129"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "poi",
+                    "elementType": "all",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        },
+                        {
+                            "weight": "1.00"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "poi",
+                    "elementType": "labels",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "poi",
+                    "elementType": "labels.text",
+                    "stylers": [
+                        {
+                            "color": "#5c8459"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "poi",
+                    "elementType": "labels.icon",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        },
+                        {
+                            "color": "#5c8459"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "poi.attraction",
+                    "elementType": "labels.icon",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "poi.business",
+                    "elementType": "all",
+                    "stylers": [
+                        {
+                            "visibility": "simplified"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "poi.business",
+                    "elementType": "geometry",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "poi.business",
+                    "elementType": "labels",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road",
+                    "elementType": "all",
+                    "stylers": [
+                        {
+                            "saturation": -100
+                        },
+                        {
+                            "lightness": 45
+                        },
+                        {
+                            "visibility": "on"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "all",
+                    "stylers": [
+                        {
+                            "visibility": "simplified"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "geometry",
+                    "stylers": [
+                        {
+                            "visibility": "on"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "geometry.fill",
+                    "stylers": [
+                        {
+                            "weight": "10.00"
+                        },
+                        {
+                            "color": "#315539"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "geometry.stroke",
+                    "stylers": [
+                        {
+                            "weight": "2"
+                        },
+                        {
+                            "color": "#151f17"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "labels.text.fill",
+                    "stylers": [
+                        {
+                            "visibility": "on"
+                        },
+                        {
+                            "color": "#fbfbfb"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "labels.text.stroke",
+                    "stylers": [
+                        {
+                            "color": "#283129"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.highway.controlled_access",
+                    "elementType": "geometry",
+                    "stylers": [
+                        {
+                            "visibility": "on"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.highway.controlled_access",
+                    "elementType": "labels",
+                    "stylers": [
+                        {
+                            "visibility": "on"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.highway.controlled_access",
+                    "elementType": "labels.text.fill",
+                    "stylers": [
+                        {
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.highway.controlled_access",
+                    "elementType": "labels.text.stroke",
+                    "stylers": [
+                        {
+                            "color": "#283129"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.arterial",
+                    "elementType": "all",
+                    "stylers": [
+                        {
+                            "visibility": "on"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.arterial",
+                    "elementType": "geometry.fill",
+                    "stylers": [
+                        {
+                            "weight": "10.00"
+                        },
+                        {
+                            "color": "#315539"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.arterial",
+                    "elementType": "geometry.stroke",
+                    "stylers": [
+                        {
+                            "weight": "2"
+                        },
+                        {
+                            "color": "#151f17"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.arterial",
+                    "elementType": "labels.text.fill",
+                    "stylers": [
+                        {
+                            "weight": "1"
+                        },
+                        {
+                            "color": "#f9f8f8"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.arterial",
+                    "elementType": "labels.text.stroke",
+                    "stylers": [
+                        {
+                            "weight": "1"
+                        },
+                        {
+                            "visibility": "on"
+                        },
+                        {
+                            "color": "#283129"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.arterial",
+                    "elementType": "labels.icon",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "road.local",
+                    "elementType": "all",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "transit",
+                    "elementType": "all",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "water",
+                    "elementType": "all",
+                    "stylers": [
+                        {
+                            "color": "#32657a"
+                        },
+                        {
+                            "visibility": "on"
+                        }
+                    ]
+                },
+                {
+                    "featureType": "water",
+                    "elementType": "labels",
+                    "stylers": [
+                        {
+                            "visibility": "off"
+                        }
+                    ]
+                }
             ]
         """.trimIndent()
 }

--- a/app/src/main/java/com/example/jeepni/feature/home/JsonMapStyle.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/JsonMapStyle.kt
@@ -1,0 +1,215 @@
+package com.example.jeepni.feature.home
+
+/* edit with https://mapstyle.withgoogle.com/ */
+
+object JsonMapStyle {
+    val LIGHT_MAP_STYLE =
+    """
+        [
+          {
+            "featureType": "water",
+            "elementType": "geometry",
+            "stylers": [
+              {
+                "color": "#069420"
+              }
+            ]
+          }
+        ]
+        
+    """.trimIndent()
+    val DARK_MAP_STYLE =
+        """
+            [
+              {
+                "featureType": "all",
+                "elementType": "geometry",
+                "stylers": [
+                  {
+                    "color": "#242f3e"
+                  }
+                ]
+              },
+              {
+                "featureType": "all",
+                "elementType": "labels.text.stroke",
+                "stylers": [
+                  {
+                    "lightness": -80
+                  }
+                ]
+              },
+              {
+                "featureType": "administrative",
+                "elementType": "labels.text.fill",
+                "stylers": [
+                  {
+                    "color": "#746855"
+                  }
+                ]
+              },
+              {
+                "featureType": "administrative.locality",
+                "elementType": "labels.text.fill",
+                "stylers": [
+                  {
+                    "color": "#d59563"
+                  }
+                ]
+              },
+              {
+                "featureType": "poi",
+                "elementType": "labels.text.fill",
+                "stylers": [
+                  {
+                    "color": "#d59563"
+                  }
+                ]
+              },
+              {
+                "featureType": "poi.park",
+                "elementType": "geometry",
+                "stylers": [
+                  {
+                    "color": "#263c3f"
+                  }
+                ]
+              },
+              {
+                "featureType": "poi.park",
+                "elementType": "labels.text.fill",
+                "stylers": [
+                  {
+                    "color": "#6b9a76"
+                  }
+                ]
+              },
+              {
+                "featureType": "road",
+                "elementType": "geometry.fill",
+                "stylers": [
+                  {
+                    "color": "#2b3544"
+                  }
+                ]
+              },
+              {
+                "featureType": "road",
+                "elementType": "labels.text.fill",
+                "stylers": [
+                  {
+                    "color": "#9ca5b3"
+                  }
+                ]
+              },
+              {
+                "featureType": "road.arterial",
+                "elementType": "geometry.fill",
+                "stylers": [
+                  {
+                    "color": "#38414e"
+                  }
+                ]
+              },
+              {
+                "featureType": "road.arterial",
+                "elementType": "geometry.stroke",
+                "stylers": [
+                  {
+                    "color": "#212a37"
+                  }
+                ]
+              },
+              {
+                "featureType": "road.highway",
+                "elementType": "geometry.fill",
+                "stylers": [
+                  {
+                    "color": "#746855"
+                  }
+                ]
+              },
+              {
+                "featureType": "road.highway",
+                "elementType": "geometry.stroke",
+                "stylers": [
+                  {
+                    "color": "#1f2835"
+                  }
+                ]
+              },
+              {
+                "featureType": "road.highway",
+                "elementType": "labels.text.fill",
+                "stylers": [
+                  {
+                    "color": "#f3d19c"
+                  }
+                ]
+              },
+              {
+                "featureType": "road.local",
+                "elementType": "geometry.fill",
+                "stylers": [
+                  {
+                    "color": "#38414e"
+                  }
+                ]
+              },
+              {
+                "featureType": "road.local",
+                "elementType": "geometry.stroke",
+                "stylers": [
+                  {
+                    "color": "#212a37"
+                  }
+                ]
+              },
+              {
+                "featureType": "transit",
+                "elementType": "geometry",
+                "stylers": [
+                  {
+                    "color": "#2f3948"
+                  }
+                ]
+              },
+              {
+                "featureType": "transit.station",
+                "elementType": "labels.text.fill",
+                "stylers": [
+                  {
+                    "color": "#d59563"
+                  }
+                ]
+              },
+              {
+                "featureType": "water",
+                "elementType": "geometry",
+                "stylers": [
+                  {
+                    "color": "#17263c"
+                  }
+                ]
+              },
+              {
+                "featureType": "water",
+                "elementType": "labels.text.fill",
+                "stylers": [
+                  {
+                    "color": "#515c6d"
+                  }
+                ]
+              },
+              {
+                "featureType": "water",
+                "elementType": "labels.text.stroke",
+                "stylers": [
+                  {
+                    "lightness": -20
+                  }
+                ]
+              }
+            ]
+        """.trimIndent()
+}

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -69,14 +69,22 @@ fun MainScreen(
             permission = Manifest.permission.ACCESS_FINE_LOCATION,
             isGranted = isGranted
         )
+        if (isGranted) {
+            viewModel.onEvent(MainEvent.OnToggleDrivingMode(true))
+        }
     }
     val multiplePermissionResultLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+        var isAllGranted = false
         permissions.keys.forEach { permission ->
             viewModel.onPermissionResult(
                 permission = permission,
                 isGranted = permissions[permission] == true
             )
+            isAllGranted = permissions[permission] == true
+        }
+        if (isAllGranted) {
+            viewModel.onEvent(MainEvent.OnToggleDrivingMode(true))
         }
     }
 

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -200,6 +200,28 @@ fun MainScreen(
                             viewModel.onEvent(MainEvent.OnSaveDailyAnalyticClick(salary.toDouble(), fuelCost.toDouble()))}
                     )
                 }
+                val activity = LocalContext.current as MainActivity //TODO: find another solution. this is probably a memory leak..
+                dialogQueue.reversed().forEach { permission ->
+                    PermissionDialog(
+                        permissionTextProvider = when (permission) {
+                            Manifest.permission.ACCESS_FINE_LOCATION -> {
+                                LocationPermissionTextProvider()
+                            }
+                            else -> {
+                                return@forEach
+                            }
+                        },
+                        isPermanentlyDeclined = ! shouldShowRequestPermissionRationale(activity, permission) ,
+                        onDismiss = viewModel::dismissDialog,
+                        onConfirm = {
+                            multiplePermissionResultLauncher.launch(
+                                arrayOf(permission)
+                            )
+                        },
+                        onGoToAppSettings = activity::openAppSettings
+                    )
+
+                }
             }
         }
 }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -43,12 +43,16 @@ import com.example.jeepni.core.ui.PermissionDialog
 import com.example.jeepni.core.ui.theme.*
 import com.example.jeepni.util.LocationPermissionTextProvider
 import com.example.jeepni.util.UiEvent
+import com.google.android.gms.maps.GoogleMapOptions
+import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.maps.android.compose.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.*
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -338,6 +342,10 @@ fun DrivingModeOnContent(
     onMapLoaded : () -> Unit,
 ) {
 
+    val cebuBounds = LatLngBounds(
+        LatLng(9.263293, 123.119609),
+        LatLng(11.476362, 125.494500)
+    )
 
     Surface {
         Column (
@@ -352,10 +360,21 @@ fun DrivingModeOnContent(
                     .padding(8.dp),
                 cameraPositionState = cameraPositionState,
                 onMapLoaded = onMapLoaded,
+                googleMapOptionsFactory = {
+                    val cameraPosition = CameraPosition.Builder()
+                        .target(LatLng(10.3157, 123.8854)) // set to a point within cebuBounds
+                        .zoom(10f)
+                        .build()
+                    GoogleMapOptions()
+                        .maxZoomPreference(18f)
+                        .minZoomPreference(10f)
+                        .latLngBoundsForCameraTarget(cebuBounds)
+                        .camera(cameraPosition)
+                },
                 uiSettings = MapUiSettings(
                     myLocationButtonEnabled = true,
                     compassEnabled = true,
-                    zoomControlsEnabled = true,
+                    zoomControlsEnabled = true
                 ),
                 properties = MapProperties(
                     mapStyleOptions = MapStyleOptions(
@@ -363,9 +382,15 @@ fun DrivingModeOnContent(
                             JsonMapStyle.DARK_MAP_STYLE
                         else
                             JsonMapStyle.LIGHT_MAP_STYLE
-                    ),
-                )
+                    )
+                ),
             ) {
+//                Polygon(
+//                    points = Coordinates.CebuIslandCoordinates,
+//                    strokeWidth = 2F,
+//                    strokeColor = Color.Blue,
+//                    fillColor = Color.Blue.copy(0.25f) // Blue with 25% opacity
+//                )
                 Marker(
                     state = MarkerState(position = targetPosition),
                     title = "You", //TODO: give the name of the driver?
@@ -384,6 +409,7 @@ fun DrivingModeOnContent(
         }
     }
 }
+
 @Composable
 fun DrivingModeOffContent(paddingValues: PaddingValues) {
     Surface {

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -432,12 +432,18 @@ fun TopActionBar(
                     Icon(Icons.Filled.LocationOn, contentDescription = null)
                     Text(
                         modifier = Modifier.padding(4.dp, 0.dp),
-                        text = distance
+                        text = distance,
+                        fontFamily = quicksandFontFamily,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp
                     )
                     Icon(painterResource(R.drawable.white_timer_24), contentDescription = null)
                     Text(
                         modifier = Modifier.padding(4.dp, 0.dp),
-                        text = time
+                        text = time,
+                        fontFamily = quicksandFontFamily,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp
                     )
                 }
             },

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -342,9 +342,16 @@ fun DrivingModeOnContent(
     onMapLoaded : () -> Unit,
 ) {
 
-    val cebuBounds = LatLngBounds(
-        LatLng(9.263293, 123.119609),
-        LatLng(11.476362, 125.494500)
+    val cebuBounds = LatLngBounds.Builder()
+        .include(LatLng(9.386076, 123.258371))
+        .include(LatLng(11.399790, 124.135218))
+        .build()
+
+    val holePoints = listOf(
+        cebuBounds.northeast,
+        LatLng(cebuBounds.northeast.latitude, cebuBounds.southwest.longitude),
+        cebuBounds.southwest,
+        LatLng(cebuBounds.southwest.latitude, cebuBounds.northeast.longitude)
     )
 
     Surface {
@@ -366,8 +373,8 @@ fun DrivingModeOnContent(
                         .zoom(10f)
                         .build()
                     GoogleMapOptions()
-                        .maxZoomPreference(18f)
-                        .minZoomPreference(10f)
+                        .maxZoomPreference(14.0f)
+                        .minZoomPreference(9.0f)
                         .latLngBoundsForCameraTarget(cebuBounds)
                         .camera(cameraPosition)
                 },
@@ -385,12 +392,26 @@ fun DrivingModeOnContent(
                     )
                 ),
             ) {
-//                Polygon(
-//                    points = Coordinates.CebuIslandCoordinates,
-//                    strokeWidth = 2F,
-//                    strokeColor = Color.Blue,
-//                    fillColor = Color.Blue.copy(0.25f) // Blue with 25% opacity
-//                )
+                Polygon(
+                    points = listOf(
+                        LatLng(85.0,90.0),
+                        LatLng(85.0,0.1),
+                        LatLng(85.0,-90.0),
+                        LatLng(85.0,-179.9),
+                        LatLng(0.0,-179.9),
+                        LatLng(-85.0,-179.9),
+                        LatLng(-85.0,-90.0),
+                        LatLng(-85.0,0.1),
+                        LatLng(-85.0,90.0),
+                        LatLng(-85.0,179.9),
+                        LatLng(0.0,179.9),
+                        LatLng(85.0,179.9),
+                    ),
+                    strokeWidth = 0F,
+                    fillColor = Color.White,
+                    holes = listOf(holePoints),
+                    zIndex = 10000.0f,
+                )
                 Marker(
                     state = MarkerState(position = targetPosition),
                     title = "You", //TODO: give the name of the driver?
@@ -404,7 +425,6 @@ fun DrivingModeOnContent(
                     .background(Color.LightGray),
                 horizontalArrangement = Arrangement.Center
             ) {
-
             }
         }
     }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -537,6 +537,7 @@ fun Menu(
         modifier = Modifier.background(Color.Transparent),
         drawerState = drawerState,
         drawerContent = { MenuContent(email = email,  drawerState = drawerState, scope = scope, onProfileClicked = onProfileClicked, menuItems = menuItems) },
+        gesturesEnabled = drawerState.isOpen,
         content = content
     )
 }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -175,7 +175,7 @@ fun MainScreen(
                                         paddingValues = it,
                                         cameraPositionState = viewModel.cameraPositionState,
                                         targetPosition = viewModel.targetPosition,
-                                        onMapLoaded = viewModel::onMapLoaded
+                                        onMapLoaded = {} //viewModel::onMapLoaded
                                     )
                                 } else {
                                     DrivingModeOffContent(paddingValues = it)

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -30,6 +30,9 @@ import com.example.jeepni.R
 import com.example.jeepni.core.ui.JeepNiTextField
 import com.example.jeepni.core.ui.theme.*
 import com.example.jeepni.util.UiEvent
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.*
@@ -256,21 +259,31 @@ fun LogDailyStatDialog(
 
 @Composable
 fun DrivingModeOnContent(paddingValues : PaddingValues) {
+    val singapore = LatLng(1.35, 103.87)
+
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(singapore, 10f)
+    }
     Surface {
         Column (
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize(),
             ) {
-            Text(
+
+            GoogleMap(
                 modifier = Modifier
-                    .padding(8.dp)
                     .fillMaxWidth()
                     .weight(0.8f)
-                    .background(Color.Gray),
-                textAlign = TextAlign.Center,
-                text = "Map"
-            )
+                    .padding(8.dp),
+
+                cameraPositionState = cameraPositionState
+            ) {
+                Marker(
+                    state = MarkerState(position = singapore),
+                    title = "Singapore:)"
+                )
+            }
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -407,7 +420,7 @@ fun MenuContent(
                         )
                         Text(email?:"no email found", /* TODO: show user name instead */
                             modifier = Modifier
-                                .padding(12.dp,8.dp)
+                                .padding(12.dp, 8.dp)
                                 .clickable {
                                     onProfileClicked()
                                 },

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -163,7 +163,11 @@ fun MainScreen(
                                     .fillMaxSize()
                             ) {
                                 if (viewModel.drivingMode) {
-                                    DrivingModeOnContent(paddingValues = it)
+                                    DrivingModeOnContent(
+                                        paddingValues = it,
+                                        cameraPositionState = viewModel.cameraPositionState,
+                                        targetPosition = viewModel.targetPosition
+                                    )
                                 } else {
                                     DrivingModeOffContent(paddingValues = it)
                                 }
@@ -326,12 +330,16 @@ fun LogDailyStatDialog(
 }
 
 @Composable
-fun DrivingModeOnContent(paddingValues : PaddingValues) {
-    val singapore = LatLng(1.35, 103.87)
+fun DrivingModeOnContent(
+    paddingValues : PaddingValues,
+    targetPosition : LatLng,
+    cameraPositionState: CameraPositionState,
+    onMapLoaded : () -> Unit = {},
 
-    val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(singapore, 10f)
-    }
+    viewModel: MainViewModel = hiltViewModel(), //TODO: only for testing purposes. delete after.
+) {
+
+
     Surface {
         Column (
             modifier = Modifier

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -213,7 +213,7 @@ fun MainScreen(
                             viewModel.onEvent(MainEvent.OnSaveDailyAnalyticClick(salary.toDouble(), fuelCost.toDouble()))}
                     )
                 }
-                val activity = LocalContext.current as MainActivity //TODO: find another solution. this is probably a memory leak..
+                val activity = LocalContext.current as MainActivity //apparently this is not a memory leak!
                 dialogQueue.reversed().forEach { permission ->
                     PermissionDialog(
                         permissionTextProvider = when (permission) {

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -75,13 +75,13 @@ fun MainScreen(
     }
     val multiplePermissionResultLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-        var isAllGranted = false
+        var isAllGranted = true
         permissions.keys.forEach { permission ->
             viewModel.onPermissionResult(
                 permission = permission,
                 isGranted = permissions[permission] == true
             )
-            isAllGranted = permissions[permission] == true
+            isAllGranted = permissions[permission] == true && isAllGranted
         }
         if (isAllGranted) {
             viewModel.onEvent(MainEvent.OnToggleDrivingMode(true))

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -133,7 +133,16 @@ fun MainScreen(
                             drawerState = drawerState,
                             drivingMode = viewModel.drivingMode,
                             scope = coroutineScope,
-                            toggleDrivingMode ={ viewModel.onEvent(MainEvent.OnToggleDrivingMode(it)) },
+                            toggleDrivingMode ={
+
+                                val permissionCheckResult = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+
+                                if (permissionCheckResult == PackageManager.PERMISSION_GRANTED) {
+                                    viewModel.onEvent(MainEvent.OnToggleDrivingMode(it))
+                                } else {
+                                    locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                                }
+                            },
                             distance = viewModel.distanceState,
                             time = viewModel.timeState,
                             onDistanceChange = {viewModel.onEvent(MainEvent.OnDistanceChange(it)) },

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -43,8 +43,8 @@ import com.example.jeepni.core.ui.PermissionDialog
 import com.example.jeepni.core.ui.theme.*
 import com.example.jeepni.util.LocationPermissionTextProvider
 import com.example.jeepni.util.UiEvent
-import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.maps.android.compose.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -352,12 +352,31 @@ fun DrivingModeOnContent(
                     .fillMaxWidth()
                     .weight(0.8f)
                     .padding(8.dp),
-
-                cameraPositionState = cameraPositionState
+                cameraPositionState = cameraPositionState,
+                onMapLoaded = {
+                    viewModel.onMapLoaded()
+                    onMapLoaded()
+                },
+                uiSettings = MapUiSettings(
+                    myLocationButtonEnabled = true,
+                    compassEnabled = true,
+                    zoomControlsEnabled = true,
+                ),
+                properties = MapProperties(
+                    mapStyleOptions = MapStyleOptions(
+                        if (isSystemInDarkTheme())
+                            JsonMapStyle.DARK_MAP_STYLE
+                        else
+                            JsonMapStyle.LIGHT_MAP_STYLE
+                    ),
+                )
             ) {
                 Marker(
-                    state = MarkerState(position = singapore),
-                    title = "Singapore:)"
+                    state = MarkerState(position = targetPosition),
+                    title = "You", //TODO: give the name of the driver?
+                    onClick = {
+                        viewModel.simulateLocationChange() // Delete after
+                        false}
                 )
             }
             Row(

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -166,7 +166,8 @@ fun MainScreen(
                                     DrivingModeOnContent(
                                         paddingValues = it,
                                         cameraPositionState = viewModel.cameraPositionState,
-                                        targetPosition = viewModel.targetPosition
+                                        targetPosition = viewModel.targetPosition,
+                                        onMapLoaded = viewModel::onMapLoaded
                                     )
                                 } else {
                                     DrivingModeOffContent(paddingValues = it)
@@ -334,9 +335,7 @@ fun DrivingModeOnContent(
     paddingValues : PaddingValues,
     targetPosition : LatLng,
     cameraPositionState: CameraPositionState,
-    onMapLoaded : () -> Unit = {},
-
-    viewModel: MainViewModel = hiltViewModel(), //TODO: only for testing purposes. delete after.
+    onMapLoaded : () -> Unit,
 ) {
 
 
@@ -346,17 +345,13 @@ fun DrivingModeOnContent(
                 .padding(paddingValues)
                 .fillMaxSize(),
             ) {
-
             GoogleMap(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(0.8f)
                     .padding(8.dp),
                 cameraPositionState = cameraPositionState,
-                onMapLoaded = {
-                    viewModel.onMapLoaded()
-                    onMapLoaded()
-                },
+                onMapLoaded = onMapLoaded,
                 uiSettings = MapUiSettings(
                     myLocationButtonEnabled = true,
                     compassEnabled = true,
@@ -374,9 +369,6 @@ fun DrivingModeOnContent(
                 Marker(
                     state = MarkerState(position = targetPosition),
                     title = "You", //TODO: give the name of the driver?
-                    onClick = {
-                        viewModel.simulateLocationChange() // Delete after
-                        false}
                 )
             }
             Row(

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -206,6 +206,23 @@ class MainViewModel
             visiblePermissionDialogQueue.add(permission)
         }
     }
+    private val locationCallBack = object : LocationCallback() {
+        override fun onLocationResult(locationResult: LocationResult) {
+            val lastLocation = locationResult.lastLocation!!
+            latitude = lastLocation.latitude
+            longitude = lastLocation.longitude
+            targetPosition = LatLng(latitude, longitude)
+
+            viewModelScope.launch {
+                try {
+                    cameraPositionState.animate(CameraUpdateFactory.newLatLng(targetPosition))
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    e.printStackTrace()
+                }
+            }
+        }
+    }
 
     @SuppressLint("MissingPermission")
     private fun requestNewLocationData() {

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -1,5 +1,7 @@
 package com.example.jeepni.feature.home
 
+import android.annotation.SuppressLint
+import android.os.Looper
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -11,6 +13,7 @@ import com.example.jeepni.core.data.repository.AuthRepository
 import com.example.jeepni.core.data.repository.DailyAnalyticsRepository
 import com.example.jeepni.util.Screen
 import com.example.jeepni.util.UiEvent
+import com.google.android.gms.location.*
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -66,23 +69,17 @@ class MainViewModel
     var timeState by mutableStateOf(convertMillisToTime(time))
         private set
 
-
-    private var longitude = 1.35
-    private var latitude = 100.8
-    var targetPosition by mutableStateOf(LatLng(longitude, latitude))
+    //cebu basic coords
+    private var latitude by mutableStateOf(10.3157)
+    private var longitude by mutableStateOf(123.8854)
+    var targetPosition by mutableStateOf(LatLng(latitude, longitude))
         private set
-    var cameraPositionState by mutableStateOf(CameraPositionState())
+    var cameraPositionState by mutableStateOf(CameraPositionState(CameraPosition.fromLatLngZoom(targetPosition, 15f)))
         private set
 
     fun onMapLoaded() {
-        viewModelScope.launch {
-            try {
-                cameraPositionState.animate(CameraUpdateFactory.newCameraPosition(CameraPosition.fromLatLngZoom(targetPosition, 10f)))
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e
-                e.printStackTrace()
-            }
-        }
+        cameraPositionState.move(CameraUpdateFactory.newCameraPosition(CameraPosition.fromLatLngZoom(targetPosition, 15f)))
+
     }
     fun simulateLocationChange() {
         sendUiEvent(UiEvent.ShowToast("starting..."))

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -126,6 +126,8 @@ class MainViewModel
             }
             is MainEvent.OnToggleDrivingMode -> {
                 drivingMode = event.isDrivingMode
+                requestNewLocationData()
+
             }
             is MainEvent.OnUndoDeleteClick -> { //TODO: Broken
                 deletedStat?.let {
@@ -205,4 +207,16 @@ class MainViewModel
         }
     }
 
+    @SuppressLint("MissingPermission")
+    private fun requestNewLocationData() {
+        //TODO: these parameters may be recalibrated to optimize performance
+        val locationRequest = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 1000)
+            .setWaitForAccurateLocation(false)
+//            .setMinUpdateDistanceMeters(50f)
+            .setMinUpdateIntervalMillis(500)
+            .setMaxUpdateDelayMillis(3*1000)
+            .build()
+
+        fusedLocationProviderClient.requestLocationUpdates(locationRequest, locationCallBack, Looper.myLooper())
+    }
 }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -28,7 +28,7 @@ class MainViewModel
 @Inject constructor(
     private val repository: DailyAnalyticsRepository,
     private val authRepo: AuthRepository,
-    //savedStateHandle: SavedStateHandle //contains navigation arguments
+    private val fusedLocationProviderClient: FusedLocationProviderClient
 ) : ViewModel() {
 
     var user by mutableStateOf(authRepo.getUser())

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -229,7 +229,7 @@ class MainViewModel
         //TODO: these parameters may be recalibrated to optimize performance
         val locationRequest = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 1000)
             .setWaitForAccurateLocation(false)
-//            .setMinUpdateDistanceMeters(50f)
+            .setMinUpdateDistanceMeters(10f) // prevents updates when driver is not moving. can save power
             .setMinUpdateIntervalMillis(500)
             .setMaxUpdateDelayMillis(3*1000)
             .build()

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -77,10 +77,9 @@ class MainViewModel
     var cameraPositionState by mutableStateOf(CameraPositionState(CameraPosition.fromLatLngZoom(targetPosition, 15f)))
         private set
 
-    fun onMapLoaded() {
-        cameraPositionState.move(CameraUpdateFactory.newCameraPosition(CameraPosition.fromLatLngZoom(targetPosition, 15f)))
-
-    }
+//    fun onMapLoaded() {
+//        cameraPositionState.move(CameraUpdateFactory.newCameraPosition(CameraPosition.fromLatLngZoom(targetPosition, 15f)))
+//    }
     fun simulateLocationChange() {
         sendUiEvent(UiEvent.ShowToast("starting..."))
         viewModelScope.launch {
@@ -127,7 +126,6 @@ class MainViewModel
             is MainEvent.OnToggleDrivingMode -> {
                 drivingMode = event.isDrivingMode
                 requestNewLocationData()
-
             }
             is MainEvent.OnUndoDeleteClick -> { //TODO: Broken
                 deletedStat?.let {

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -15,6 +15,7 @@ import com.example.jeepni.util.Screen
 import com.example.jeepni.util.UiEvent
 import com.google.android.gms.location.*
 import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.CameraPositionState

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.jeepni.feature.home
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
@@ -25,9 +26,8 @@ class MainViewModel
 ) : ViewModel() {
 
     var user by mutableStateOf(authRepo.getUser())
-//    init {
-//        user = savedStateHandle.get<String>("email") ?: ""
-//    }
+
+    val visiblePermissionDialogQueue = mutableStateListOf<String>()
 
     // create a sharedFlow for one-time events: events that you don't want to rerun on configuration changes
 
@@ -153,4 +153,18 @@ class MainViewModel
             _uiEvent.send(event)
         }
     }
+
+    fun dismissDialog() {
+        visiblePermissionDialogQueue.removeFirst()
+    }
+
+    fun onPermissionResult(
+        permission: String,
+        isGranted : Boolean
+    ) {
+        if (!isGranted && !visiblePermissionDialogQueue.contains(permission)) {
+            visiblePermissionDialogQueue.add(permission)
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/jeepni/util/PermissionTextProvider.kt
+++ b/app/src/main/java/com/example/jeepni/util/PermissionTextProvider.kt
@@ -1,0 +1,15 @@
+package com.example.jeepni.util
+
+interface PermissionTextProvider {
+    fun getDescription(isPermanentlyDeclined : Boolean) : String
+}
+
+class LocationPermissionTextProvider : PermissionTextProvider {
+    override fun getDescription(isPermanentlyDeclined: Boolean): String {
+        return if (isPermanentlyDeclined) {
+            "It seems you permanently declined location permissions.  Go to the app settings to grant it."
+        } else {
+            "JeepNi needs access to your location to give you a better app experience."
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ plugins {
     id 'org.jetbrains.kotlin.kapt' version '1.8.0'
     id 'com.google.dagger.hilt.android' version "$dagger_hilt_version" apply false //hilt gradle plugin configuration with Plugins DSL
     id 'com.google.devtools.ksp' version '1.8.0-1.0.9' //ksp plugin for compose destinations
+
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false //for hiding map API key
+
 }
 
 allprojects {


### PR DESCRIPTION
## Changes

### Displaying the Map (finally)

I initially thought that I would have to do some crazy XML to Compose stuff with the AndroidView composable since a lot of the resources that I read stated that Google Maps doesn't have a Compose API yet. Thankfully, a Google Maps Compose Library was recently added last year.

- Added a google map composable to the main screen. It is displayed when driver mode is toggled on. (changes)
  - Swiping around the google map composable creates conflicts with the gesture controls of the menu drawer. To fix this, the menu drawer gestures are disabled when the menu drawer is closed. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/7a09227c179cbc8e692c5fa13242e72119090953#diff-e344f8c25f4e47d4996b0bcb53c80e9bd1ba8e91fa67886eb5e20d7e763659e5R540))
- Added light and dark mode map styles to the google map composable. However, the map styles are not yet fully customized. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/2aff7c856173c2eb905c9d021c64f8ac2201eaf4))
- Custom map UI settings such as the compass and the locationButton were added to the map composable. However, they don't seem to show on the screen. I think its an API problem tho. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/c66d28fb2c81ad2cd7021a116504dbfc72d54ae1#diff-e344f8c25f4e47d4996b0bcb53c80e9bd1ba8e91fa67886eb5e20d7e763659e5R360-R363)) 

### Getting Location Permissions

Without the location permissions, Google Maps cannot get updates of the user's location.


- Permissions are added to the manifest so we can  request for them in the app. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/a89ca68ca07dd2986e52f8f215795f685563cd61))
- Location permission requests are launched when the driving mode switch is toggled on. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/00ce84c9791c252e457df9032640089cbe302171#diff-e344f8c25f4e47d4996b0bcb53c80e9bd1ba8e91fa67886eb5e20d7e763659e5R140-R144))
  - I set up the permission requests in such a way that multiple permission requests can be launched when the driver mode is toggled on. This will be especially useful if we do plan to have a calling feature that requires microphone access or if we plan to continue tracking distance and time as a background service when the user closes the application. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/faa9c7f77d7bee816f945f24e6944012c238db29#diff-dc3bad78ace96db9e9c983fbadf2d801fa350087c6bc36e11e02759d5b57dc55R156-R169))
    - A permission is added to a permissionDialogQueue when the permission is denied. Each denied permission in the queue will launch an alert dialog. The permission is dequeued when the dialog closes.
  - If the permission requests have been granted, the driving mode can be toggled on.
  - If the user does not grant permissions, driving mode cannot be toggled on. However, we still allow the user to use other JeepNi features. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/bd8417c58f1fbb17cf20445ad04cccbecca4310c#diff-e344f8c25f4e47d4996b0bcb53c80e9bd1ba8e91fa67886eb5e20d7e763659e5R204-R224))
    - When the user denies the permission request once, an alert dialog is displayed indicating the importance of the permission request. If the request is launched and denied again, the permissions will be permanently denied. Whenever the user tries to toggle the driver mode on, the user will be prompted via an alert dialog to manually grant the permissions in the app's settings, which is launched when the user clicks the "Go to Settings" Button. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/bd8417c58f1fbb17cf20445ad04cccbecca4310c#diff-e344f8c25f4e47d4996b0bcb53c80e9bd1ba8e91fa67886eb5e20d7e763659e5R203-R224))
- The app data's [backup storage](https://stackoverflow.com/a/15744733/13907596) flag is changed to false. This allows the user's preferences and app configurations (especially, permissions) to be reset every time the application is reinstalled. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/3fbe550fd424013a7957ec05a900380e6048e68b#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR12))


### Getting User Location and Updating Map State

With the Map composable and Location permissions, user location can be obtained which can be used to update the user's marker on the map.

The [FusedLocationProvider](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderClient) is a part of Google's Location Services that uses Wi-Fi and GPS to *efficiently* obtain user location.

- The `FusedLocationProviderClient` [dependency is created](https://github.com/kyle-gonzales/jeepni/pull/31/commits/cfde16f5276cb31d1f8676851611f24ce3084d92#diff-303321dcf6421171359f5c70b83b2c89a0a2f9d02fe11c3d4b7e751bf200280eR68-R72) and is [injected](https://github.com/kyle-gonzales/jeepni/pull/31/commits/cfde16f5276cb31d1f8676851611f24ce3084d92#diff-303321dcf6421171359f5c70b83b2c89a0a2f9d02fe11c3d4b7e751bf200280eR68-R72) into the `MainViewModel`.
- When driver mode is toggled on, the user's current location is automatically requested ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/3967dea9b162cfe936b9debf5f04e8cb869e89b7#diff-dc3bad78ace96db9e9c983fbadf2d801fa350087c6bc36e11e02759d5b57dc55R127-R130))
  - The LocationProvider continues to collect updates on the user's location at set intervals ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/3967dea9b162cfe936b9debf5f04e8cb869e89b7#diff-dc3bad78ace96db9e9c983fbadf2d801fa350087c6bc36e11e02759d5b57dc55R127-R130))
  - Optimized performance of location provider by setting the minimum update distance to 10 meters to avoid receiving location updates when driver is not moving. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/2b51a622d3476bb7837d0fb3bd902533914e16da#diff-dc3bad78ace96db9e9c983fbadf2d801fa350087c6bc36e11e02759d5b57dc55R232))
- The marker on the map is updated and the map is animated every time a new location is obtained ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/3967dea9b162cfe936b9debf5f04e8cb869e89b7#diff-dc3bad78ace96db9e9c983fbadf2d801fa350087c6bc36e11e02759d5b57dc55R127-R130))
  - When the driver mode is initially toggled on, the initial camera position state of the map composable and marker composable are set to the coordinates of Cebu City as a *temporary*. This is because the Location Provider cannot provider the user's location in time for the map to load its initial state. However, this configuration can be improved in the future. ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/f2e4826f6d4936c4f3990009cf8a685f60c57143#diff-dc3bad78ace96db9e9c983fbadf2d801fa350087c6bc36e11e02759d5b57dc55R72-R77))

---

### Additional Changes (April 17, 2023)

- Driver mode is automatically toggled on when permissions are granted ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/d93fd907acf4dcd84908d8627f71520b3f348e76))
  - Permission requests are launched when the toggle button is pressed. However, the toggle button remains off even after permissions are granted. The switch has to be pressed again so that driver mode can finally be toggled on. In this commit, logic is added to the activity result callback. Now, granting permissions automatically turns driver mode on. We save one user press. lol. 
- Fixed the UI of the distance and time trackers on the `MainScreen` action bar ([changes](https://github.com/kyle-gonzales/jeepni/pull/31/commits/ce9a2a5b4a0db83f8f7654e04a8f6b51ea500b90))
  - Decreased the font size and changed the font family to be consistent with the rest of JeepNi
