### PR TITLE
feature: Track time when driving mode is toggled on

### DIFF
--- a/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class DailyAnalytics(
     val date: String = getCurrentDateString(),
-    val timer: Double = 0.0,
+    val timer: Long = 0L,
     val salary: Double = 0.0,
     val fuelCost: Double = 0.0,
 ) : Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
@@ -2,13 +2,12 @@ package com.example.jeepni.core.data.model
 
 import android.os.Parcelable
 import com.example.jeepni.feature.home.getCurrentDateString
-import com.example.jeepni.feature.home.getCurrentTimeString
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class DailyAnalytics(
     val date: String = getCurrentDateString(),
-    val timer: String = getCurrentTimeString(),
+    val timer: Double = 0.0,
     val salary: Double = 0.0,
     val fuelCost: Double = 0.0,
 ) : Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
@@ -2,11 +2,13 @@ package com.example.jeepni.core.data.model
 
 import android.os.Parcelable
 import com.example.jeepni.feature.home.getCurrentDateString
+import com.example.jeepni.feature.home.getCurrentTimeString
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class DailyAnalytics (
-    val date : String = getCurrentDateString(),
-    val salary : Double = 0.0,
-    val fuelCost : Double = 0.0,
+data class DailyAnalytics(
+    val date: String = getCurrentDateString(),
+    val timer: String = getCurrentTimeString(),
+    val salary: Double = 0.0,
+    val fuelCost: Double = 0.0,
 ) : Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepository.kt
@@ -1,16 +1,21 @@
 package com.example.jeepni.core.data.repository
 
 import com.example.jeepni.core.data.model.DailyAnalytics
+import com.example.jeepni.feature.home.getCurrentDateString
 import kotlinx.coroutines.flow.Flow
 
 interface DailyAnalyticsRepository {
 
-    suspend fun logDailyStat(dailyStat : DailyAnalytics)
+    suspend fun logDailyStat(dailyStat: DailyAnalytics)
 
     suspend fun updateDailyStat(dailyStat: DailyAnalytics)
 
+    suspend fun saveTimer(dailyStat: DailyAnalytics)
+
+    suspend fun fetchTimer(date: String = getCurrentDateString()): String
+
     suspend fun deleteDailyStat()
 
-    fun getDailyStats() : Flow<List<DailyAnalytics>>
+    fun getDailyStats(): Flow<List<DailyAnalytics>>
 
 }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepository.kt
@@ -10,7 +10,7 @@ interface DailyAnalyticsRepository {
 
     suspend fun updateDailyStat(dailyStat: DailyAnalytics)
 
-    suspend fun saveTimer(dailyStat: DailyAnalytics)
+    suspend fun saveTimer(dailyStat: DailyAnalytics) : Boolean
 
     suspend fun fetchTimer(date: String = getCurrentDateString()): String
 

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
@@ -91,11 +91,7 @@ class DailyAnalyticsRepositoryImpl(
             .document(date)
             .get()
             .await()
-            .get("timer")
-
-        if (timer == null) {
-            return "0"
-        }
+            .get("timer") ?: return "0"
 
         return timer.toString()
 

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
@@ -45,16 +45,22 @@ class DailyAnalyticsRepositoryImpl(
         logDailyStat(dailyStat)
     }
 
-    override suspend fun saveTimer(dailyStat: DailyAnalytics) {
+    override suspend fun saveTimer(dailyStat: DailyAnalytics) : Boolean {
         // ONLY SAVES ON THE TIMER FIELD
-        usersRef.document(auth.currentUser!!.uid)
-            .collection("analytics")
-            .document(dailyStat.date)
-            .update(
-                mapOf(
-                    "timer" to dailyStat.timer,
-                )
-            )
+        return try {
+            usersRef.document(auth.currentUser!!.uid)
+                .collection("analytics")
+                .document(dailyStat.date)
+                .update(
+                    mapOf(
+                        "timer" to dailyStat.timer,
+                    )
+                ).await()
+            true
+        } catch (e : Exception) {
+            e.printStackTrace()
+            false
+        }
     }
 
     override suspend fun fetchTimer(date: String): String {
@@ -64,6 +70,10 @@ class DailyAnalyticsRepositoryImpl(
             .get()
             .await()
             .get("timer")
+
+        if (timer == null) {
+            return "0"
+        }
 
         return timer.toString()
 

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
@@ -7,11 +7,9 @@ import com.example.jeepni.core.data.model.DailyAnalytics
 import com.example.jeepni.feature.home.getCurrentDateString
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.CollectionReference
-
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-
 import kotlinx.coroutines.tasks.await
 
 class DailyAnalyticsRepositoryImpl(
@@ -30,10 +28,12 @@ class DailyAnalyticsRepositoryImpl(
         usersRef.document(auth.currentUser!!.uid)
             .collection("analytics")
             .document(dailyStat.date)
-            .set(hashMapOf(
-                "salary" to dailyStat.salary,
-                "fuelCost" to dailyStat.fuelCost
-            ))
+            .update(
+                mapOf(
+                    "salary" to dailyStat.salary,
+                    "fuelCost" to dailyStat.fuelCost,
+                )
+            )
 
             .addOnSuccessListener {
                 Toast.makeText(context, "saved", Toast.LENGTH_SHORT).show()
@@ -44,6 +44,31 @@ class DailyAnalyticsRepositoryImpl(
     override suspend fun updateDailyStat(dailyStat: DailyAnalytics) {
         logDailyStat(dailyStat)
     }
+
+    override suspend fun saveTimer(dailyStat: DailyAnalytics) {
+        // ONLY SAVES ON THE TIMER FIELD
+        usersRef.document(auth.currentUser!!.uid)
+            .collection("analytics")
+            .document(dailyStat.date)
+            .update(
+                mapOf(
+                    "timer" to dailyStat.timer,
+                )
+            )
+    }
+
+    override suspend fun fetchTimer(date: String): String {
+        val timer = usersRef.document(auth.currentUser!!.uid)
+            .collection("analytics")
+            .document(date)
+            .get()
+            .await()
+            .get("timer")
+
+        return timer.toString()
+
+    }
+
 
     override suspend fun deleteDailyStat() {
         usersRef.document(auth.currentUser!!.uid)

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
@@ -59,6 +59,14 @@ class DailyAnalyticsRepositoryImpl(
             true
         } catch (e : Exception) {
             e.printStackTrace()
+            usersRef.document(auth.currentUser!!.uid)
+                .collection("analytics")
+                .document(dailyStat.date)
+                .set(
+                    mapOf(
+                        "timer" to dailyStat.timer,
+                    )
+                ).await()
             false
         }
     }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainEvent.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainEvent.kt
@@ -11,8 +11,6 @@ sealed class MainEvent {
     object OnUndoDeleteClick : MainEvent()
     data class OnSalaryChange(val salary: String) : MainEvent()
     data class OnFuelCostChange(val fuelCost: String) : MainEvent()
-    data class OnDistanceChange(val distance : String) : MainEvent()
-    data class OnTimeChange(val distance : String) : MainEvent()
     object OnProfileClicked: MainEvent()
     object OnChartsClicked : MainEvent()
     object OnCheckUpClicked : MainEvent()

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -157,8 +157,6 @@ fun MainScreen(
                             },
                             distance = viewModel.distanceState,
                             time = viewModel.timeState,
-                            onDistanceChange = {viewModel.onEvent(MainEvent.OnDistanceChange(it)) },
-                            onTimeChange = {viewModel.onEvent(MainEvent.OnTimeChange(it))}
                         ) },
 
                         floatingActionButton = {
@@ -466,8 +464,6 @@ fun TopActionBar(
     toggleDrivingMode : (Boolean) -> Unit,
     distance : String,
     time : String,
-    onDistanceChange: (String) -> Unit,
-    onTimeChange : (String) -> Unit
     ) {
     Surface(
         contentColor = Color.White,

--- a/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
@@ -11,16 +11,17 @@ data class MenuItem(
     val title : String,
     val onClick : () -> Unit = {}
 )
-fun convertMillisToTime(timeInMillis: Long) : String {
+fun formatSecondsToTime(timeInSeconds: Long) : String {
 
-    val res = if (timeInMillis >= 3600000L) {
-        val hours = (timeInMillis / 3600000).toInt()
-        val rem : Int = timeInMillis.toInt() % 3600000
-        val minutes : Int = rem / 60000
+    val res = if (timeInSeconds >= 3600L) {
+        val hours = (timeInSeconds / 3600).toInt()
+        val rem : Int = timeInSeconds.toInt() % 3600
+        val minutes : Int = rem / 60
         "$hours hr $minutes min"
     } else {
-        val minutes : Int = timeInMillis.toInt() / 60000
-        "$minutes min"
+        val minutes : Int = timeInSeconds.toInt() / 60
+        val seconds : Int = timeInSeconds.toInt() % 60
+        "$minutes min $seconds s"
     }
     return res
 }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
@@ -44,7 +44,7 @@ fun isValidDecimal(text: String) : Boolean {
 }
 
 fun getCurrentDateString(): String {
-    val sdf = SimpleDateFormat("M-dd-YYYY")
+    val sdf = SimpleDateFormat("M-d-YYYY")
     return sdf.format(Date())
 
 }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
@@ -1,6 +1,7 @@
 package com.example.jeepni.feature.home
 
-import java.util.*
+import java.text.SimpleDateFormat
+import java.util.Date
 
 /*
 * helper functions
@@ -41,13 +42,15 @@ fun isValidDecimal(text: String) : Boolean {
     return regex.matches(text)
 }
 
-fun getCurrentDateString() : String {
-    val c = Calendar.getInstance()
-    val year = c.get(Calendar.YEAR)
-    val month = ((c.get(Calendar.MONTH))+1).toString()
-    val day = c.get(Calendar.DAY_OF_MONTH)
+fun getCurrentDateString(): String {
+    val sdf = SimpleDateFormat("M-dd-YYYY")
+    return sdf.format(Date())
 
-    return "$month-$day-$year"
+}
+
+fun getCurrentTimeString(): String {
+    val sdf = SimpleDateFormat("hh:mm:ss")
+    return sdf.format(Date())
 }
 
 //fun logDailyStatUpdate(context: Context, salary : String, fuelCost : String) {

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -82,6 +82,7 @@ class MainViewModel
     init {
         viewModelScope.launch {
             time = repository.fetchTimer().toLong()
+            timeState = formatSecondsToTime(time)
         }
     }
     fun simulateLocationChange() {
@@ -124,6 +125,8 @@ class MainViewModel
                 viewModelScope.launch {
 //                    deletedStat = DailyAnalytics(salary.toDouble(), fuelCost.toDouble())
                     repository.deleteDailyStat()
+                    time = 0
+                    timeState = formatSecondsToTime(time)
                     sendUiEvent(UiEvent.ShowSnackBar("Daily Stat Deleted", "Undo"))
                 }
             }
@@ -149,7 +152,7 @@ class MainViewModel
                         }
                     }
                     fusedLocationProviderClient.removeLocationUpdates(locationCallBack)
-                    //TODO: update time and distance in driving mode to Firestore
+                    //TODO: update distance in driving mode to Firestore
                 }
             }
             is MainEvent.OnUndoDeleteClick -> { //TODO: Broken

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -78,6 +78,12 @@ class MainViewModel
 //    fun onMapLoaded() {
 //        cameraPositionState.move(CameraUpdateFactory.newCameraPosition(CameraPosition.fromLatLngZoom(targetPosition, 15f)))
 //    }
+
+    init {
+        viewModelScope.launch {
+            time = repository.fetchTimer().toLong()
+        }
+    }
     fun simulateLocationChange() {
         sendUiEvent(UiEvent.ShowToast("starting..."))
         viewModelScope.launch {
@@ -129,6 +135,19 @@ class MainViewModel
                         trackTimeInDrivingMode()
                     }
                 } else {
+                    viewModelScope.launch {
+                        val result = repository.saveTimer(
+                            DailyAnalytics(
+                                timer = time
+                            )
+                        )
+                        if (result) {
+                            sendUiEvent(UiEvent.ShowToast("saved timer"))
+                        } else {
+                            sendUiEvent(UiEvent.ShowToast("FAILED to save timer"))
+
+                        }
+                    }
                     fusedLocationProviderClient.removeLocationUpdates(locationCallBack)
                     //TODO: update time and distance in driving mode to Firestore
                 }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -66,7 +66,7 @@ class MainViewModel
 
     var distanceState by mutableStateOf(convertDistanceToString(distance))
         private set
-    var timeState by mutableStateOf(convertMillisToTime(time))
+    var timeState by mutableStateOf(formatSecondsToTime(time))
         private set
 
     //cebu basic coords

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -15,7 +15,6 @@ import com.example.jeepni.util.Screen
 import com.example.jeepni.util.UiEvent
 import com.google.android.gms.location.*
 import com.google.android.gms.maps.CameraUpdateFactory
-import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.CameraPositionState
@@ -149,13 +148,6 @@ class MainViewModel
             is MainEvent.OnFuelCostChange -> {
                 fuelCost = event.fuelCost
                 isValidFuelCost = isValidDecimal(fuelCost)
-            }
-            is MainEvent.OnDistanceChange -> {
-                distanceState = convertDistanceToString(distance)
-
-            }
-            is MainEvent.OnTimeChange -> {
-                timeState = convertMillisToTime(time)
             }
             is MainEvent.OnLogOutClick -> {
                 viewModelScope.launch {

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -128,6 +128,9 @@ class MainViewModel
                     viewModelScope.launch {
                         trackTimeInDrivingMode()
                     }
+                } else {
+                    fusedLocationProviderClient.removeLocationUpdates(locationCallBack)
+                    //TODO: update time and distance in driving mode to Firestore
                 }
             }
             is MainEvent.OnUndoDeleteClick -> { //TODO: Broken
@@ -218,6 +221,7 @@ class MainViewModel
             latitude = lastLocation.latitude
             longitude = lastLocation.longitude
             targetPosition = LatLng(latitude, longitude)
+            //Log.i("LOCATION UPDATE", "$latitude, $longitude")
 
             viewModelScope.launch {
                 try {


### PR DESCRIPTION
Tracking time is a valuable and simple, yet effective metric to determine the efficiency of drivers while they are on the road. Drivers will be able to see how long they spend working in a day. Additionally, this analytic will work well with the JeepNi's machine learning capabilities to create predictions and provide drivers with valuable recommendations to improve their efficiency.

### Changes

- Added a tracker while driving mode is toggled on ([changes](https://github.com/kyle-gonzales/jeepni/pull/39/commits/5c4a8466978d46d670700c217641e01d461d6734#diff-dc3bad78ace96db9e9c983fbadf2d801fa350087c6bc36e11e02759d5b57dc55R126-R202))
  - this timer runs on a separate thread and is updated every second. ([changes](https://github.com/kyle-gonzales/jeepni/pull/39/commits/5c4a8466978d46d670700c217641e01d461d6734#diff-dc3bad78ace96db9e9c983fbadf2d801fa350087c6bc36e11e02759d5b57dc55R126-R202))
    - *Note: this is probably an inefficient solution, which may be fixed in further updates*
- The timer field on the action bar shows the current time spent in driving mode
  - the timer, measured in seconds, is a `long` value that gets formatted into a string that is shown on the screen ([changes](https://github.com/kyle-gonzales/jeepni/pull/39/commits/48efd4a3cbed22833e3a0b265bb16cdc355c96e4#diff-a8a68a8575fcd042791c6fb16f7b347ec444e4959e7a91a8596e74a0b042bdd6R14-R24))
- When the user toggles driving mode off, the current running time is saved to FireStore ([changes](https://github.com/kyle-gonzales/jeepni/pull/39/commits/6c6c651dbebc791e84c20862199c1f2300759b3e#diff-65de941391850d50fc18cc948f8b98da8f4f3f9bfadc246e8d7101d1b454177eR50-R86))
- When the user is first directed to the `MainScreen` JeepNi checks FireStore for any pre-existing times. If so, it automatically sets this value as the current state ([changes](https://github.com/kyle-gonzales/jeepni/pull/39/commits/d462c6fb4e36abbbf870d4dc74fc754dddb7cb4b#diff-dc3bad78ace96db9e9c983fbadf2d801fa350087c6bc36e11e02759d5b57dc55R82-R87))

---

### Other Changes

- stopped receiving location updates when driving mode is toggled off ([changes](https://github.com/kyle-gonzales/jeepni/pull/39/commits/bf475de3e45396e089797a6a8099187042489f8c))
  - to optimize JeepNi, we made sure to stop asking for location updates when they are no longer needed
- removed unused events in the `MainViewModel` ([changes](https://github.com/kyle-gonzales/jeepni/pull/39/commits/deed600048226598ecdf4a58396c00c4a4181081))
  - the source of updates of Distance and Time while driving mode is on is from the ViewModel, not the screen. Thus, onDistanceChange and onTimeChange are not necessary
