### PR TITLE
DEPRECATED storing alarms in initial checkup

### DIFF
--- a/app/src/main/java/com/example/jeepni/core/data/model/Notification.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/Notification.kt
@@ -3,9 +3,9 @@ package com.example.jeepni.core.data.model
 import android.os.Parcelable
 import com.example.jeepni.feature.home.getCurrentDateString
 import kotlinx.parcelize.Parcelize
-
 @Parcelize
 data class Notification(
-    val date: String = getCurrentDateString(),
+    val notifyDate: String = getCurrentDateString(),
     val type: String = "default",
+    val userID: String = "0",
 ) : Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/model/Notification.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/Notification.kt
@@ -1,0 +1,11 @@
+package com.example.jeepni.core.data.model
+
+import android.os.Parcelable
+import com.example.jeepni.feature.home.getCurrentDateString
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Notification(
+    val date: String = getCurrentDateString(),
+    val type: String = "default",
+) : Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/NotificationsRepository.kt
@@ -1,0 +1,12 @@
+package com.example.jeepni.core.data.repository
+
+import com.example.jeepni.core.data.model.Notification
+
+interface NotificationsRepository {
+
+    suspend fun addNotification(notification: Notification)
+
+    suspend fun getNotifications(): List<Notification>
+
+
+}

--- a/app/src/main/java/com/example/jeepni/core/data/repository/NotificationsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/NotificationsRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.example.jeepni.core.data.repository
+
+import com.example.jeepni.core.data.model.Notification
+import com.google.firebase.firestore.FirebaseFirestore
+import java.text.SimpleDateFormat
+
+class NotificationsRepositoryImpl(
+    private val db: FirebaseFirestore,
+) : NotificationsRepository {
+
+    override suspend fun addNotification(notification: Notification) {
+        val data = hashMapOf(
+            "notifyDate" to SimpleDateFormat("MM-dd-yyyy").parse(notification.notifyDate),  //TODO: do something about this, not sure if this is how to do it
+            "type" to notification.type,
+            "userID" to db.document("/users/${notification.userID}")
+        )
+        try {
+            db.collection("notifications")
+                .add(data)
+
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    override suspend fun getNotifications(): List<Notification> {
+        return mutableListOf()
+    }
+}

--- a/app/src/main/java/com/example/jeepni/di/AppModule.kt
+++ b/app/src/main/java/com/example/jeepni/di/AppModule.kt
@@ -33,25 +33,31 @@ object AppModule {
     @Singleton
     fun provideJeepsRepository(
         app: Application,
-        auth : FirebaseAuth,
-        db : FirebaseFirestore
-    ) : JeepsRepository = JeepsRepositoryImpl(app, auth, db)
+        auth: FirebaseAuth,
+        db: FirebaseFirestore,
+    ): JeepsRepository = JeepsRepositoryImpl(app, auth, db)
 
     @Provides
     @Singleton
     fun provideUserDetailRepository(
-        app : Application,
-        auth : FirebaseAuth,
-        db : FirebaseFirestore
-    ) : UserDetailRepository = UserDetailRepositoryImpl(app, auth, db)
+        app: Application,
+        auth: FirebaseAuth,
+        db: FirebaseFirestore,
+    ): UserDetailRepository = UserDetailRepositoryImpl(app, auth, db)
+
+    @Provides
+    @Singleton
+    fun provideNotificationsRepository(
+        db: FirebaseFirestore,
+    ): NotificationsRepository = NotificationsRepositoryImpl(db)
 
     @Provides
     @Singleton
     fun provideDailyAnalyticsRepository(
-        auth : FirebaseAuth,
-        usersRef : CollectionReference,
-        app: Application
-    ) : DailyAnalyticsRepository = DailyAnalyticsRepositoryImpl(auth, usersRef, app)
+        auth: FirebaseAuth,
+        usersRef: CollectionReference,
+        app: Application,
+    ): DailyAnalyticsRepository = DailyAnalyticsRepositoryImpl(auth, usersRef, app)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
@@ -1,6 +1,6 @@
 package com.example.jeepni.feature.home
 
-import java.util.*
+import java.util.Calendar
 
 /*
 * helper functions
@@ -49,37 +49,3 @@ fun getCurrentDateString() : String {
 
     return "$month-$day-$year"
 }
-
-//fun logDailyStatUpdate(context: Context, salary : String, fuelCost : String) {
-//    val db = Firebase.firestore
-//
-//    val dat = hashMapOf(
-//        "salary" to (salary.ifBlank { "0" }),
-//        "fuelCost" to (fuelCost.ifBlank { "0" })
-//    )
-//    db.collection("users")
-//        .document("0") // TODO: change to firebase generated user ID
-//        .collection("analytics")
-//        .document(getCurrentDateString())
-//        .set(dat)
-//        .addOnSuccessListener {
-//            Toast.makeText(context, "Saved!", Toast.LENGTH_SHORT).show()
-//        }
-//        .addOnFailureListener {
-//            Toast.makeText(context, "Error making changes", Toast.LENGTH_SHORT).show()
-//        }
-//}
-//fun logDailyStatDelete(){
-//    val db = Firebase.firestore
-//
-//    db.collection("users")
-//        .document("0") // TODO: change to firebase generated user ID
-//        .collection("analytics")
-//        .document(getCurrentDateString())
-//        .delete()
-//        .addOnSuccessListener {
-//        }
-//        .addOnFailureListener {
-//        }
-//
-//}

--- a/app/src/main/java/com/example/jeepni/feature/initial_checkup/InitialCheckupViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/initial_checkup/InitialCheckupViewModel.kt
@@ -2,19 +2,27 @@ package com.example.jeepni.feature.initial_checkup
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.jeepni.core.data.model.Notification
+import com.example.jeepni.core.data.repository.AuthRepository
+import com.example.jeepni.core.data.repository.NotificationsRepository
+import com.example.jeepni.feature.home.getCurrentDateString
 import com.example.jeepni.util.Screen
 import com.example.jeepni.util.UiEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 
 @HiltViewModel
 class InitialCheckupViewModel @Inject constructor(
+    private val repository: NotificationsRepository,
+    private val auth: AuthRepository,
 
-) : ViewModel() {
+    ) : ViewModel() {
 
     private var _uiEvent = Channel<UiEvent>()
     val uiEvent = _uiEvent.receiveAsFlow()
@@ -22,8 +30,18 @@ class InitialCheckupViewModel @Inject constructor(
     fun onEvent(event: InitialCheckupEvent) {
         when(event) {
             is InitialCheckupEvent.OnSaveClicked -> {
-                // TODO: save data to firestore
-                sendUiEvent(UiEvent.Navigate(Screen.MainScreen.route, "0"))
+                viewModelScope.launch {
+                    val data = Notification(
+                        getCurrentDateString(),
+                        "default checkup",
+                        auth.getUser()?.uid ?: "user"
+                    ) // TODO: replace 1st & 2nd parameters with proper values
+                    repository.addNotification(data)
+                    withContext(Dispatchers.Main.immediate) {
+                        sendUiEvent(UiEvent.Navigate(Screen.MainScreen.route, "0"))
+                    }
+                }
+
             }
         }
     }


### PR DESCRIPTION
These changes are for the implementation of Firebase support for notifications and checkup events.

# Changes
- Added data model for notifications ([link](https://github.com/kyle-gonzales/jeepni/commit/58f48992f8a37b743772e394ea035694709c8693))
- Added a repository for notifications ([interface link](https://github.com/kyle-gonzales/jeepni/commit/60f9bf6bea2bba1c786cd1f10b2db94af608ac57), [impl link](https://github.com/kyle-gonzales/jeepni/commit/7d36aee153592ee8a247a24cddc9ac6c233cda0f))
- Updated AppModule and InitialCheckUpViewModel ([link](https://github.com/kyle-gonzales/jeepni/commit/f702249fd9201c111d2feb58dcb414f538daa2fe))


### Comments
_I am not sure if what I did is what we intend to do but I would like to be reoriented on what needs to be done if it's not_

Currently, the Notifications data model accepts three parameters: 
- *notifyDate* (the date when the notification fires), 
- *type* (text to distinguish this notification from other notifications), and 
- *userID* (supposedly to link it with a user in the users collection, might change this if we decide to just place it directly under the user document).

Will still have to update the parameters for the user inputs and stuff. 