### PR TITLE
feature: Notification and alarm feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,8 +30,9 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
         </activity>
+
+        <receiver android:name="com.example.jeepni.util.AlarmBroadcastReceiver"/>
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM"/>
     <application
         android:name=".JeepNiApp"
         android:allowBackup="false"

--- a/app/src/main/java/com/example/jeepni/MainActivity.kt
+++ b/app/src/main/java/com/example/jeepni/MainActivity.kt
@@ -1,5 +1,10 @@
 package com.example.jeepni
 
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,6 +15,7 @@ import com.example.jeepni.core.data.repository.AuthRepository
 import com.example.jeepni.core.data.repository.UserDetailRepository
 import com.example.jeepni.core.ui.theme.JeepNiTheme
 import com.example.jeepni.feature.analytics.AnalyticsViewModel
+import com.example.jeepni.util.Constants
 import com.example.jeepni.util.Navigation
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.google.android.gms.location.*
@@ -48,6 +54,7 @@ class MainActivity : ComponentActivity() {
                     Manifest.permission.POST_NOTIFICATIONS,
                 )
             )
+            createNotificationChannel()
         } else {
             //TODO: support older android versions
         }
@@ -57,5 +64,11 @@ class MainActivity : ComponentActivity() {
                 Navigation(navController, auth, userDetailsRepository)
             }
         }
+    }
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(Constants.CHANNEL_ID, Constants.CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT).apply {
+        }
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.createNotificationChannel(channel)
     }
 }

--- a/app/src/main/java/com/example/jeepni/MainActivity.kt
+++ b/app/src/main/java/com/example/jeepni/MainActivity.kt
@@ -14,7 +14,6 @@ import androidx.navigation.NavHostController
 import com.example.jeepni.core.data.repository.AuthRepository
 import com.example.jeepni.core.data.repository.UserDetailRepository
 import com.example.jeepni.core.ui.theme.JeepNiTheme
-import com.example.jeepni.feature.analytics.AnalyticsViewModel
 import com.example.jeepni.util.Constants
 import com.example.jeepni.util.Navigation
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
@@ -35,17 +34,14 @@ class MainActivity : ComponentActivity() {
     }
     private lateinit var navController: NavHostController
     @Inject
-    lateinit var auth : AuthRepository // automatically injected. no need for initialization
+    private lateinit var auth : AuthRepository // automatically injected. no need for initialization
     @Inject
-    lateinit var userDetailsRepository : UserDetailRepository
-
-    private lateinit var analyticsViewModel : AnalyticsViewModel
-
-    //    private val signUpViewModel by viewModels<SignUpViewModel>()
+    private lateinit var userDetailsRepository : UserDetailRepository
+    //private val analyticsViewModel by viewModels<AnalyticsViewModel>()
+    //private val signUpViewModel by viewModels<SignUpViewModel>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-//        analyticsViewModel = ViewModelProvider(this)[AnalyticsViewModel::class.java]
-//        analyticsViewModel.logAnalytics()
+            //analyticsViewModel.logAnalytics()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             multiplePermissionsLauncher.launch(
                 arrayOf(

--- a/app/src/main/java/com/example/jeepni/MainActivity.kt
+++ b/app/src/main/java/com/example/jeepni/MainActivity.kt
@@ -3,6 +3,7 @@ package com.example.jeepni
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.navigation.NavHostController
 import com.example.jeepni.core.data.repository.AuthRepository
@@ -18,6 +19,14 @@ import javax.inject.Inject
 @OptIn(ExperimentalAnimationApi::class)
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private val multiplePermissionsLauncher = registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+        permissions ->
+        permissions.entries.forEach {
+            val permission = it.key
+            val isGranted = it.value
+        }
+    }
     private lateinit var navController: NavHostController
     @Inject
     lateinit var auth : AuthRepository // automatically injected. no need for initialization
@@ -31,6 +40,17 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 //        analyticsViewModel = ViewModelProvider(this)[AnalyticsViewModel::class.java]
 //        analyticsViewModel.logAnalytics()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            multiplePermissionsLauncher.launch(
+                arrayOf(
+                    Manifest.permission.SCHEDULE_EXACT_ALARM,
+                    Manifest.permission.USE_EXACT_ALARM,
+                    Manifest.permission.POST_NOTIFICATIONS,
+                )
+            )
+        } else {
+            //TODO: support older android versions
+        }
         setContent {
             JeepNiTheme {
                 navController = rememberAnimatedNavController()

--- a/app/src/main/java/com/example/jeepni/di/AppModule.kt
+++ b/app/src/main/java/com/example/jeepni/di/AppModule.kt
@@ -1,8 +1,10 @@
 package com.example.jeepni.di
 
+import android.app.AlarmManager
 import android.app.Application
 import android.content.Context
 import com.example.jeepni.core.data.repository.*
+import com.example.jeepni.util.AlarmScheduler
 import com.google.android.gms.location.LocationServices
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
@@ -70,4 +72,17 @@ object AppModule {
     fun providesFusedLocationProviderClient (
         @ApplicationContext context : Context
     ) = LocationServices.getFusedLocationProviderClient(context)
+
+    @Provides
+    @Singleton
+    fun providesAlarmManager (
+        @ApplicationContext context : Context
+    ) = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+    @Provides
+    @Singleton
+    fun providesAlarmScheduler (
+        @ApplicationContext context : Context,
+        alarmManager: AlarmManager
+    ) = AlarmScheduler(context, alarmManager)
 }

--- a/app/src/main/java/com/example/jeepni/feature/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/analytics/AnalyticsScreen.kt
@@ -44,6 +44,9 @@ fun AnalyticsScreen(
                 is UiEvent.ShowToast -> {
                     Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
                 }
+                 else -> {
+
+                 }
             }
         }
     }

--- a/app/src/main/java/com/example/jeepni/feature/checkup/CheckUpScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/checkup/CheckUpScreen.kt
@@ -5,9 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
@@ -17,9 +15,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.jeepni.core.ui.JeepNiText
-import com.example.jeepni.core.ui.SolidButton
-import com.example.jeepni.core.ui.theme.quicksandFontFamily
-import com.example.jeepni.feature.profile.ProfileEvent
 import com.example.jeepni.util.UiEvent
 
 @Composable
@@ -47,6 +42,7 @@ fun CheckUpScreen (
                 is UiEvent.ShowToast -> {
                     Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
                 }
+                else -> {}
             }
         }
     }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainEvent.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainEvent.kt
@@ -11,8 +11,6 @@ sealed class MainEvent {
     object OnUndoDeleteClick : MainEvent()
     data class OnSalaryChange(val salary: String) : MainEvent()
     data class OnFuelCostChange(val fuelCost: String) : MainEvent()
-    data class OnDistanceChange(val distance : String) : MainEvent()
-    data class OnTimeChange(val distance : String) : MainEvent()
     object OnProfileClicked: MainEvent()
     object OnChartsClicked : MainEvent()
     object OnCheckUpClicked : MainEvent()

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -41,8 +41,7 @@ import com.example.jeepni.R
 import com.example.jeepni.core.ui.JeepNiTextField
 import com.example.jeepni.core.ui.PermissionDialog
 import com.example.jeepni.core.ui.theme.*
-import com.example.jeepni.util.LocationPermissionTextProvider
-import com.example.jeepni.util.UiEvent
+import com.example.jeepni.util.*
 import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -114,6 +113,7 @@ fun MainScreen(
                 is UiEvent.ShowToast -> {
                     Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
                 }
+                else -> {}
             }
         }
 

--- a/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainScreen.kt
@@ -157,8 +157,6 @@ fun MainScreen(
                             },
                             distance = viewModel.distanceState,
                             time = viewModel.timeState,
-                            onDistanceChange = {viewModel.onEvent(MainEvent.OnDistanceChange(it)) },
-                            onTimeChange = {viewModel.onEvent(MainEvent.OnTimeChange(it))}
                         ) },
 
                         floatingActionButton = {
@@ -466,8 +464,6 @@ fun TopActionBar(
     toggleDrivingMode : (Boolean) -> Unit,
     distance : String,
     time : String,
-    onDistanceChange: (String) -> Unit,
-    onTimeChange : (String) -> Unit
     ) {
     Surface(
         contentColor = Color.White,

--- a/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
@@ -11,16 +11,17 @@ data class MenuItem(
     val title : String,
     val onClick : () -> Unit = {}
 )
-fun convertMillisToTime(timeInMillis: Long) : String {
+fun formatSecondsToTime(timeInSeconds: Long) : String {
 
-    val res = if (timeInMillis >= 3600000L) {
-        val hours = (timeInMillis / 3600000).toInt()
-        val rem : Int = timeInMillis.toInt() % 3600000
-        val minutes : Int = rem / 60000
+    val res = if (timeInSeconds >= 3600L) {
+        val hours = (timeInSeconds / 3600).toInt()
+        val rem : Int = timeInSeconds.toInt() % 3600
+        val minutes : Int = rem / 60
         "$hours hr $minutes min"
     } else {
-        val minutes : Int = timeInMillis.toInt() / 60000
-        "$minutes min"
+        val minutes : Int = timeInSeconds.toInt() / 60
+        val seconds : Int = timeInSeconds.toInt() % 60
+        "$minutes min $seconds s"
     }
     return res
 }

--- a/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
@@ -50,37 +50,3 @@ fun getCurrentDateString() : String {
 
     return "$month-$day-$year"
 }
-
-//fun logDailyStatUpdate(context: Context, salary : String, fuelCost : String) {
-//    val db = Firebase.firestore
-//
-//    val dat = hashMapOf(
-//        "salary" to (salary.ifBlank { "0" }),
-//        "fuelCost" to (fuelCost.ifBlank { "0" })
-//    )
-//    db.collection("users")
-//        .document("0") // TODO: change to firebase generated user ID
-//        .collection("analytics")
-//        .document(getCurrentDateString())
-//        .set(dat)
-//        .addOnSuccessListener {
-//            Toast.makeText(context, "Saved!", Toast.LENGTH_SHORT).show()
-//        }
-//        .addOnFailureListener {
-//            Toast.makeText(context, "Error making changes", Toast.LENGTH_SHORT).show()
-//        }
-//}
-//fun logDailyStatDelete(){
-//    val db = Firebase.firestore
-//
-//    db.collection("users")
-//        .document("0") // TODO: change to firebase generated user ID
-//        .collection("analytics")
-//        .document(getCurrentDateString())
-//        .delete()
-//        .addOnSuccessListener {
-//        }
-//        .addOnFailureListener {
-//        }
-//
-//}

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -66,7 +66,7 @@ class MainViewModel
 
     var distanceState by mutableStateOf(convertDistanceToString(distance))
         private set
-    var timeState by mutableStateOf(convertMillisToTime(time))
+    var timeState by mutableStateOf(formatSecondsToTime(time))
         private set
 
     //cebu basic coords

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -15,7 +15,6 @@ import com.example.jeepni.util.Screen
 import com.example.jeepni.util.UiEvent
 import com.google.android.gms.location.*
 import com.google.android.gms.maps.CameraUpdateFactory
-import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.CameraPositionState
@@ -149,13 +148,6 @@ class MainViewModel
             is MainEvent.OnFuelCostChange -> {
                 fuelCost = event.fuelCost
                 isValidFuelCost = isValidDecimal(fuelCost)
-            }
-            is MainEvent.OnDistanceChange -> {
-                distanceState = convertDistanceToString(distance)
-
-            }
-            is MainEvent.OnTimeChange -> {
-                timeState = convertMillisToTime(time)
             }
             is MainEvent.OnLogOutClick -> {
                 viewModelScope.launch {

--- a/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainViewModel.kt
@@ -128,6 +128,9 @@ class MainViewModel
                     viewModelScope.launch {
                         trackTimeInDrivingMode()
                     }
+                } else {
+                    fusedLocationProviderClient.removeLocationUpdates(locationCallBack)
+                    //TODO: update time and distance in driving mode to Firestore
                 }
             }
             is MainEvent.OnUndoDeleteClick -> { //TODO: Broken
@@ -218,6 +221,7 @@ class MainViewModel
             latitude = lastLocation.latitude
             longitude = lastLocation.longitude
             targetPosition = LatLng(latitude, longitude)
+            //Log.i("LOCATION UPDATE", "$latitude, $longitude")
 
             viewModelScope.launch {
                 try {

--- a/app/src/main/java/com/example/jeepni/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/profile/ProfileScreen.kt
@@ -45,6 +45,7 @@ fun ProfileScreen (
                 is UiEvent.ShowToast -> {
                     Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
                 }
+                else -> {}
             }
         }
     }

--- a/app/src/main/java/com/example/jeepni/util/AlarmBroadcastReceiver.kt
+++ b/app/src/main/java/com/example/jeepni/util/AlarmBroadcastReceiver.kt
@@ -3,10 +3,21 @@ package com.example.jeepni.util
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
+import androidx.annotation.RequiresApi
 
 abstract class AlarmBroadcastReceiver : BroadcastReceiver() {
 
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onReceive(context: Context?, intent: Intent?) {
+        val notification = intent?.getParcelableExtra("notification_content", String::class.java/*holder class*/) ?: return
 
+        showSimpleNotification(
+            context!!,
+            channelId = Constants.CHANNEL_ID,
+            notificationId = 0,
+            textTitle = "",
+            textContent = ""
+        )
     }
 }

--- a/app/src/main/java/com/example/jeepni/util/AlarmBroadcastReceiver.kt
+++ b/app/src/main/java/com/example/jeepni/util/AlarmBroadcastReceiver.kt
@@ -1,0 +1,12 @@
+package com.example.jeepni.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+abstract class AlarmBroadcastReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+
+    }
+}

--- a/app/src/main/java/com/example/jeepni/util/AlarmScheduler.kt
+++ b/app/src/main/java/com/example/jeepni/util/AlarmScheduler.kt
@@ -1,0 +1,42 @@
+package com.example.jeepni.util
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class AlarmScheduler (
+    private val context : Context,
+    private val alarmManager : AlarmManager
+) {
+    fun schedule(dateTime : LocalDateTime, interval : LocalDateTime, notification : String /*currently a holder*/) {
+
+        val intent = Intent(context, AlarmBroadcastReceiver::class.java).apply {
+            putExtra("notification_object", notification) //TODO: this is currently a placeholder that will be updated;
+        }
+        alarmManager.setInexactRepeating(
+            AlarmManager.RTC_WAKEUP,
+            dateTime.atZone(ZoneId.systemDefault()).toEpochSecond() * 1000,
+            interval.atZone(ZoneId.systemDefault()).toEpochSecond() * 1000,
+            PendingIntent.getBroadcast(
+                context,
+                dateTime.hashCode(),
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        )
+    }
+
+    fun cancel (dateTime : LocalDateTime, message : String) {
+        alarmManager.cancel(
+            PendingIntent.getBroadcast(
+                context,
+                dateTime.hashCode(),
+                Intent(context, AlarmBroadcastReceiver::class.java),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/jeepni/util/Constants.kt
+++ b/app/src/main/java/com/example/jeepni/util/Constants.kt
@@ -1,0 +1,21 @@
+package com.example.jeepni.util
+
+object Constants {
+    const val CHANNEL_ID = "jeepni_by_algofirst_notification_channel_id"
+    //shown in user settings
+    const val CHANNEL_NAME = "JeepNi Checkup Notifications"
+
+    const val DRIVING_MODE_TURNED_ON_NOTIFICATION = 0
+    const val CHANGE_OIL_NOTIFICATION = 1
+    const val LTFRB_INSPECTION_NOTIFICATION = 2
+    const val LTO_INSPECTION_NOTIFICATION = 3
+    const val TIRE_CHANGE_NOTIFICATION = 4
+    const val SIDE_MIRRORS_REPAIR_NOTIFICATION = 5
+    const val WIPERS_REPAIR_NOTIFICATION = 6
+    const val ENGINE_REPAIR_NOTIFICATION = 7
+    const val SEATBELT_REPAIR_NOTIFICATION = 8
+    const val BATTERY_REPAIR_NOTIFICATION = 9
+
+
+    const val FIRST_NOTIFICATION_ID = 999
+}

--- a/app/src/main/java/com/example/jeepni/util/UiEvent.kt
+++ b/app/src/main/java/com/example/jeepni/util/UiEvent.kt
@@ -12,4 +12,9 @@ sealed class UiEvent {
     data class ShowToast(
         val message : String
     ) : UiEvent()
+
+
+    data class ShowNotification(
+        val id : Int
+    ) : UiEvent()
 }

--- a/app/src/main/java/com/example/jeepni/util/utilFunctions.kt
+++ b/app/src/main/java/com/example/jeepni/util/utilFunctions.kt
@@ -1,7 +1,67 @@
 package com.example.jeepni.util
 
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.app.TaskStackBuilder
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.example.jeepni.MainActivity
+import com.example.jeepni.R
 import com.example.jeepni.core.data.model.UserDetails
 
 fun isIncompleteUserDetails(userDetails: UserDetails) : Boolean {
     return userDetails.route == "null" || userDetails.name == "null" || userDetails.name.isNullOrEmpty() || userDetails.route.isNullOrEmpty()
+}
+
+@SuppressLint("MissingPermission")
+fun showSimpleNotificationWithTapAction(
+    context: Context,
+    channelId: String,
+    notificationId: Int,
+    textTitle: String,
+    textContent: String,
+    priority: Int = NotificationCompat.PRIORITY_DEFAULT
+) {
+    val intent = Intent(context, MainActivity::class.java).apply {
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+    }
+
+    val pendingIntent: PendingIntent = TaskStackBuilder.create(context).run {
+        addNextIntentWithParentStack(intent)
+        getPendingIntent(0, PendingIntent.FLAG_IMMUTABLE)
+    }
+
+    val builder = NotificationCompat.Builder(context, channelId)
+        .setSmallIcon(R.drawable.samplelogo)
+        .setContentTitle(textTitle)
+        .setContentText(textContent)
+        .setPriority(priority)
+        .setContentIntent(pendingIntent)
+        .setAutoCancel(true)
+
+    with(NotificationManagerCompat.from(context)) {
+        notify(notificationId, builder.build())
+    }
+}
+
+@SuppressLint("MissingPermission")
+fun showSimpleNotification(
+    context: Context,
+    channelId: String,
+    notificationId: Int,
+    textTitle: String,
+    textContent: String,
+    priority: Int = NotificationCompat.PRIORITY_DEFAULT
+) {
+    val builder = NotificationCompat.Builder(context, channelId)
+        .setSmallIcon(R.drawable.samplelogo)
+        .setContentTitle(textTitle)
+        .setContentText(textContent)
+        .setPriority(priority)
+
+    with(NotificationManagerCompat.from(context)) {
+        notify(notificationId, builder.build())
+    }
 }


### PR DESCRIPTION

## Changes

### Added Support for Notifications

The core of JeepNi's Checkup Feature is to send the driver any updates or reminders (via notifications) about any upcoming repairs or inspections. This is achieved with notifications.

- created an object to hold all constant values (notification IDs, channel IDs, channel names). These are required when using notifications ([changes](https://github.com/kyle-gonzales/jeepni/commit/a7dd1d09267969e61621bbd22a60f4301c257826))
- created functions that send notifications ([changes](https://github.com/kyle-gonzales/jeepni/commit/83bc5e57a3214b0746a43bd6bb137af6ad19139e))
- added a "sending notification" within the UiEvent class. This will allow specific screens to send notifications. ([changes](https://github.com/kyle-gonzales/jeepni/commit/67235d368feb6c6ca28ec9d538f0a7546eb3bccc#diff-d534589a052eb850643a5d9688deed65c1f6eddbcc307c3d4d0751e20c2df800R17-R20))
  - since UiEvent is a sealed class, all the screens that use it will require added `else` blocks.

### Added a Broadcast Receiver

When using the Checkup feature of JeepNi, we should be able to send notifications even when the JeepNi app is not running. This is not possible without a broadcast receiver. With a broadcast receiver, JeepNi will be able to listen for system broadcasts and react to them. For example, when an alarm broadcast for a vehicle inspection is reached, JeepNi will be able to receive that alarm and send a notification to remind the user for the upcoming vehicle inspection.

- created broadcast receiver class ([changes](https://github.com/kyle-gonzales/jeepni/commit/7aa725331459c1c0b5001f834e9e67a5ab7060a5))
- added broadcast receiver to the manifest ([changes](https://github.com/kyle-gonzales/jeepni/commit/6cfb3f3fecdea908885e044945dd260d6eb32872))
  - This allows the broadcast receiver to be registered to the android system, so that it can work while the application is not running.

### Created an Alarm Manager and Alarm Scheduler

Because JeepNi's checkup feature is heavily reliant on alarms, the `AlarmManager` API is used to set alarms and set operations when alarms are reached. To create a simpler interface when working with the `AlarmManager`, it is wrapped in a custom `AlarmScheduler` class. The `AlarmScheduler` allows you to efficiently schedule a repeating alarm that sends a broadcast when the alarm is reached.

- created alarm scheduler ([changes](https://github.com/kyle-gonzales/jeepni/commit/62438fe13d9b6bdc6758935713f3e570feee239e))
- added `AlarmManager` and `AlarmScheduler` dependencies. ([changes](https://github.com/kyle-gonzales/jeepni/commit/4a45a82f53b06859653a7dc72005fec2a540923f))
  - this will allow us to inject the `AlarmScheduler` in the view model

### Requested for Notification and Alarm Permissions in the main activity

For these changes to work, we request for notification and alarm permissions right when the application is launched.

- added permissions to the manifest ([changes](https://github.com/kyle-gonzales/jeepni/commit/d25259abd0ebbadc2c3dc3e2f690687daf07d283))
- launch requests for notifications ([changes](https://github.com/kyle-gonzales/jeepni/commit/83d5aadfcaf46dcadac65963c4ea49c8d5ab23ed))

#### *Issue

_Though the request for permissions is successful, the application is only functional when permissions are granted. Denying permissions leads to undefined (more like, untested) behavior. But due to time constraints, the implementation for when permissions are denied are not yet done. This will be resolved in the future._

---

### Minor Changes

- removed legacy dailyStat functions ([changes](https://github.com/kyle-gonzales/jeepni/commit/9ece63a50fc81ff96c90712b21cd3fbe9acdb181))