### PR TITLE
Driving mode save to Firestore

### DIFF
--- a/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
@@ -2,13 +2,12 @@ package com.example.jeepni.core.data.model
 
 import android.os.Parcelable
 import com.example.jeepni.feature.home.getCurrentDateString
-import com.example.jeepni.feature.home.getCurrentTimeString
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class DailyAnalytics(
     val date: String = getCurrentDateString(),
-    val timer: String = getCurrentTimeString(),
+    val timer: Double = 0.0,
     val salary: Double = 0.0,
     val fuelCost: Double = 0.0,
 ) : Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/model/DailyAnalytics.kt
@@ -2,11 +2,13 @@ package com.example.jeepni.core.data.model
 
 import android.os.Parcelable
 import com.example.jeepni.feature.home.getCurrentDateString
+import com.example.jeepni.feature.home.getCurrentTimeString
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class DailyAnalytics (
-    val date : String = getCurrentDateString(),
-    val salary : Double = 0.0,
-    val fuelCost : Double = 0.0,
+data class DailyAnalytics(
+    val date: String = getCurrentDateString(),
+    val timer: String = getCurrentTimeString(),
+    val salary: Double = 0.0,
+    val fuelCost: Double = 0.0,
 ) : Parcelable

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepository.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepository.kt
@@ -1,16 +1,21 @@
 package com.example.jeepni.core.data.repository
 
 import com.example.jeepni.core.data.model.DailyAnalytics
+import com.example.jeepni.feature.home.getCurrentDateString
 import kotlinx.coroutines.flow.Flow
 
 interface DailyAnalyticsRepository {
 
-    suspend fun logDailyStat(dailyStat : DailyAnalytics)
+    suspend fun logDailyStat(dailyStat: DailyAnalytics)
 
     suspend fun updateDailyStat(dailyStat: DailyAnalytics)
 
+    suspend fun saveTimer(dailyStat: DailyAnalytics)
+
+    suspend fun fetchTimer(date: String = getCurrentDateString()): String
+
     suspend fun deleteDailyStat()
 
-    fun getDailyStats() : Flow<List<DailyAnalytics>>
+    fun getDailyStats(): Flow<List<DailyAnalytics>>
 
 }

--- a/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/jeepni/core/data/repository/DailyAnalyticsRepositoryImpl.kt
@@ -7,11 +7,9 @@ import com.example.jeepni.core.data.model.DailyAnalytics
 import com.example.jeepni.feature.home.getCurrentDateString
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.CollectionReference
-
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-
 import kotlinx.coroutines.tasks.await
 
 class DailyAnalyticsRepositoryImpl(
@@ -30,10 +28,12 @@ class DailyAnalyticsRepositoryImpl(
         usersRef.document(auth.currentUser!!.uid)
             .collection("analytics")
             .document(dailyStat.date)
-            .set(hashMapOf(
-                "salary" to dailyStat.salary,
-                "fuelCost" to dailyStat.fuelCost
-            ))
+            .update(
+                mapOf(
+                    "salary" to dailyStat.salary,
+                    "fuelCost" to dailyStat.fuelCost,
+                )
+            )
 
             .addOnSuccessListener {
                 Toast.makeText(context, "saved", Toast.LENGTH_SHORT).show()
@@ -44,6 +44,31 @@ class DailyAnalyticsRepositoryImpl(
     override suspend fun updateDailyStat(dailyStat: DailyAnalytics) {
         logDailyStat(dailyStat)
     }
+
+    override suspend fun saveTimer(dailyStat: DailyAnalytics) {
+        // ONLY SAVES ON THE TIMER FIELD
+        usersRef.document(auth.currentUser!!.uid)
+            .collection("analytics")
+            .document(dailyStat.date)
+            .update(
+                mapOf(
+                    "timer" to dailyStat.timer,
+                )
+            )
+    }
+
+    override suspend fun fetchTimer(date: String): String {
+        val timer = usersRef.document(auth.currentUser!!.uid)
+            .collection("analytics")
+            .document(date)
+            .get()
+            .await()
+            .get("timer")
+
+        return timer.toString()
+
+    }
+
 
     override suspend fun deleteDailyStat() {
         usersRef.document(auth.currentUser!!.uid)

--- a/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
+++ b/app/src/main/java/com/example/jeepni/feature/home/MainUtil.kt
@@ -1,6 +1,7 @@
 package com.example.jeepni.feature.home
 
-import java.util.*
+import java.text.SimpleDateFormat
+import java.util.Date
 
 /*
 * helper functions
@@ -41,13 +42,15 @@ fun isValidDecimal(text: String) : Boolean {
     return regex.matches(text)
 }
 
-fun getCurrentDateString() : String {
-    val c = Calendar.getInstance()
-    val year = c.get(Calendar.YEAR)
-    val month = ((c.get(Calendar.MONTH))+1).toString()
-    val day = c.get(Calendar.DAY_OF_MONTH)
+fun getCurrentDateString(): String {
+    val sdf = SimpleDateFormat("M-dd-YYYY")
+    return sdf.format(Date())
 
-    return "$month-$day-$year"
+}
+
+fun getCurrentTimeString(): String {
+    val sdf = SimpleDateFormat("hh:mm:ss")
+    return sdf.format(Date())
 }
 
 //fun logDailyStatUpdate(context: Context, salary : String, fuelCost : String) {


### PR DESCRIPTION
These changes are for saving and fetching the timer for Driving Mode 

# Changes
- Extended the DailyAnalytics class to include a timer field ([link](https://github.com/kyle-gonzales/jeepni/commit/73fcf52a82b1a315638fb42e0ba135f898c3c247)) 
- Added the `saveTimer()` and `fetchTimer()` functions in the Daily Analytics Repo ([link](https://github.com/kyle-gonzales/jeepni/commit/73fcf52a82b1a315638fb42e0ba135f898c3c247))
- UNRELATED (but used): Changed a utility function to use SimpleDateFormat instead of fetching from Calendar.instance() and added another one to fetch the current time ([link](https://github.com/kyle-gonzales/jeepni/commit/73fcf52a82b1a315638fb42e0ba135f898c3c247))

### Comments
Right now, `saveTimer()` uses the DailyAnalytics data model to save the timer. I believe that it makes sense this way as the model already has a default date field value that can be used in fetching the data from Firestore, however since the default value is set to the current day, the function will only update the timer value for the current date (You can still set other the values for other dates by supplying a DailyAnalytics model with the specified date). This is similar to `fetchTimer()` but it uses a string input as the default value instead of the model. 

You can just leave the parameters for both functions blank and they'll save/fetch the timer for the current date. Though, I was wondering if we really want to lump in the Driving Mode timer together with the Analytics stuff.