### PR TITLE
Loading screen feature

### DIFF
--- a/app/src/main/java/com/example/jeepni/feature/about/AboutDriverViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/about/AboutDriverViewModel.kt
@@ -73,7 +73,7 @@ class AboutDriverViewModel
                     withContext(Dispatchers.Main) {
                         if (isUserDetailsUpdated && !isInvalidDetails) {
                             sendUiEvent(UiEvent.ShowToast("sign up process complete!"))
-                            sendUiEvent(UiEvent.Navigate(Screen.InitialCheckupScreen.route, "0")) //
+                            sendUiEvent(UiEvent.Navigate(Screen.InitialCheckupScreen.route, "0"))
                             //sendUiEvent(UiEvent.Navigate(Screen.MainScreen.route, "0"))
                         } else {
                             sendUiEvent(UiEvent.ShowToast("please complete the missing fields..."))

--- a/app/src/main/java/com/example/jeepni/feature/authentication/loading/LoadingScreen.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/loading/LoadingScreen.kt
@@ -1,0 +1,60 @@
+package com.example.jeepni.feature.authentication.loading
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.jeepni.R
+import com.example.jeepni.core.ui.theme.JeepNiTheme
+import com.example.jeepni.util.UiEvent
+
+@Composable
+fun LoadingScreen (
+    viewModel: LoadingViewModel = hiltViewModel(),
+    onNavigate : (UiEvent.Navigate) -> Unit
+) {
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collect {event ->
+            when (event) {
+                is UiEvent.Navigate -> {
+                    onNavigate(event)
+                }
+                else -> {}
+            }
+        }
+    }
+
+    JeepNiTheme {
+        Surface {
+            Column (
+                modifier = Modifier
+                    .fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.samplelogo),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .scale(0.5f)
+                        .padding(12.dp)
+
+                )
+                CircularProgressIndicator()
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/jeepni/feature/authentication/loading/LoadingViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/authentication/loading/LoadingViewModel.kt
@@ -1,0 +1,51 @@
+package com.example.jeepni.feature.authentication.loading
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.jeepni.core.data.repository.AuthRepository
+import com.example.jeepni.core.data.repository.UserDetailRepository
+import com.example.jeepni.util.Screen
+import com.example.jeepni.util.UiEvent
+import com.example.jeepni.util.isIncompleteUserDetails
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoadingViewModel @Inject constructor(
+    authRepository: AuthRepository,
+    userDetailRepository: UserDetailRepository
+) : ViewModel() {
+
+    init {
+        viewModelScope.launch {
+            val userDetails = async (Dispatchers.Default) {
+                userDetailRepository.getUserDetails()
+            }
+            val nextScreen =
+                if (userDetails.await() == null) { // user is not signed in
+                    Screen.WelcomeScreen.route
+                } else if (isIncompleteUserDetails(userDetails.await()!!)) {
+                    Screen.AboutDriverScreen.route
+                } else {
+                    Screen.MainScreen.route
+                }
+            sendUiEvent(UiEvent.Navigate(nextScreen, "0"))
+        }
+    }
+
+    private val _uiEvent = Channel<UiEvent>()
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    private fun sendUiEvent(event: UiEvent) {
+        viewModelScope.launch {
+            _uiEvent.send(event)
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/example/jeepni/feature/initial_checkup/InitialCheckupViewModel.kt
+++ b/app/src/main/java/com/example/jeepni/feature/initial_checkup/InitialCheckupViewModel.kt
@@ -174,7 +174,7 @@ class InitialCheckupViewModel @Inject constructor(
                 ltfrbDate = event.ltfrbDate
             }
             is InitialCheckupEvent.OnBackPressed -> {
-                sendUiEvent(UiEvent.PopBackStack)
+                sendUiEvent(UiEvent.Navigate(Screen.MainScreen.route, "0"))
             }
             is InitialCheckupEvent.OnBatteryClicked -> {
                 isBatteryEnabled = !isBatteryEnabled

--- a/app/src/main/java/com/example/jeepni/util/Screen.kt
+++ b/app/src/main/java/com/example/jeepni/util/Screen.kt
@@ -3,6 +3,7 @@ package com.example.jeepni.util
 sealed class Screen(val route : String) {
 
     object MainScreen : Screen("main_screen")
+    object LoadingScreen : Screen("loading_screen")
     object WelcomeScreen : Screen("welcome_screen")
     object LogInScreen : Screen("login_screen")
     object SignUpScreen: Screen("signup_screen")


### PR DESCRIPTION
We noticed that upon launching the app, there is a long delay in the Splash screen. During this time, the app is checking and verifying log-in status of the user. Previously, this was done on the main thread aka UI thread (effectively blocking it), which is characterized by a long delay in the splash screen and unresponsive behavior. To resolve this, we introduced an [intermediary `LoadingScreen`](https://github.com/kyle-gonzales/jeepni/pull/47/commits/0a4e3210891a21d72e9ac1632495418dcad63e9d#diff-d1d9ac5d85699ec219680118b27024443482bb1f079264853351e9c28a26e82cR35) between the Splash screen and the initial screen that the user is directed to.

- This change transfers the verification logic off the main thread, making the app more responsive by communicating a loading process to the user. ([changes](https://github.com/kyle-gonzales/jeepni/pull/47/commits/0a4e3210891a21d72e9ac1632495418dcad63e9d#diff-a4a7b91d9f5e6748494f507d80a3f167b8bf605a2124b644047afe2ebde415d0R25-R38))

### Other Changes
- Navigate to main screen if user skips the initial checkup ([changes](https://github.com/kyle-gonzales/jeepni/pull/47/commits/e1c170fa0ec18c663987a6e9db20eb35be85ce71))
  - initial checkup is only shown upon sign up. if the user does not want to set alarms, they will be redirected to the main screen 